### PR TITLE
Remove SRFI-1 dependency

### DIFF
--- a/rackunit-lib/info.rkt
+++ b/rackunit-lib/info.rkt
@@ -2,8 +2,7 @@
 
 (define collection 'multi)
 
-(define deps '("srfi-lite-lib"
-               "base"
+(define deps '("base"
                "data-lib"))
 
 (define pkg-desc "RackUnit testing framework")

--- a/rackunit-lib/rackunit/private/name-collector.rkt
+++ b/rackunit-lib/rackunit/private/name-collector.rkt
@@ -30,8 +30,7 @@
 
 (require "base.rkt"
          "monad.rkt"
-         "hash-monad.rkt"
-         srfi/1)
+         "hash-monad.rkt")
 
 (provide display-test-case-name
          push-suite-name!
@@ -52,11 +51,10 @@
      (cond
       ((test-success? result) (return-hash (void)))
       (else
-       (fold-right
-        (lambda (name seed)
+       (for-each
+        (lambda (name)
           (printf "~a > " name))
-        (void)
-        names)
+        (reverse names))
        (display (test-result-test-case-name result))
        (newline)
        (return-hash (void)))))))


### PR DESCRIPTION
This removes the use of the function `fold-right`, so it's not more necessary to require `srfi/1`. I think that this also remove the dependency to the `srfi-lite-lib` package, but I'm not sure how to test that. 