### PR TITLE
Use hash instead of hasheq to manage gui models for typed racket compat

### DIFF
--- a/rackunit-gui/rackunit/private/gui/view.rkt
+++ b/rackunit-gui/rackunit/private/gui/view.rkt
@@ -201,7 +201,7 @@ still be there, just not visible?
 
     ;; View Link
 
-    (define model=>view-link (make-hasheq))
+    (define model=>view-link (make-hash))
 
     (define/public (set-view-link model item)
       (hash-set! model=>view-link model item))


### PR DESCRIPTION
This is a change to accommodate rackunit gui usage from typed racket. See racket/typed-racket#8.