### PR TITLE
Allow long check-info keys

### DIFF
--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -19,7 +19,7 @@
 ;; name-width : integer
 ;;
 ;; Number of characters we reserve for the check-info name column
-(define name-width 12)
+(define minimum-name-width 12)
 
 (define (display-delimiter)
   (display "--------------------") (newline))
@@ -39,21 +39,31 @@
    [else
     (substring s 0 n)]))
 
-(define (display-check-info-name-value name value [value-printer (lambda (x) (write x) (newline))])
+(define (check-info-name-width check-info)
+  (string-length
+   (symbol->string
+    (check-info-name check-info))))
+
+(define (display-check-info-name-value max-name-width name value [value-printer (lambda (x) (write x) (newline))])
   (display (string-pad-right
             (string-append (symbol->string name) ": ")
-            name-width))
+            (max minimum-name-width (+ max-name-width 2))))
   (value-printer value))
 
-(define display-check-info
-  (match-lambda [(struct check-info (name value))
-                 (display-check-info-name-value name value)]))
+(define (display-check-info max-name-width a-check-info)
+  (match a-check-info
+    [(struct check-info (name value))
+     (display-check-info-name-value max-name-width name value)]))
 
 ;; display-check-info-stack : (listof check-info) -> void
 (define (display-check-info-stack check-info-stack)
-  (for-each
-   display-check-info
-   (strip-redundant-params check-info-stack))
+  (define max-name-width
+    (apply max
+           (map check-info-name-width check-info-stack)))
+  (define (display-check-info-with-width check-info)
+    (display-check-info max-name-width check-info))
+  (for-each display-check-info-with-width
+            (strip-redundant-params check-info-stack))
   (newline))
 
 ;; display-test-name : (U string #f) -> void

--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -58,7 +58,7 @@
 
 
 (define (check-info-stack-max-name-width check-info-stack)
-  (apply max
+  (apply max 0
          (map check-info-name-width check-info-stack)))
 
 ;; display-check-info-stack : (listof check-info) -> void

--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -14,7 +14,8 @@
          display-error
 
          display-test-failure/error
-         strip-redundant-params)
+         strip-redundant-params
+         check-info-stack-max-name-width)
 
 ;; name-width : integer
 ;;
@@ -55,11 +56,14 @@
     [(struct check-info (name value))
      (display-check-info-name-value max-name-width name value)]))
 
+
+(define (check-info-stack-max-name-width check-info-stack)
+  (apply max
+         (map check-info-name-width check-info-stack)))
+
 ;; display-check-info-stack : (listof check-info) -> void
 (define (display-check-info-stack check-info-stack)
-  (define max-name-width
-    (apply max
-           (map check-info-name-width check-info-stack)))
+  (define max-name-width (check-info-stack-max-name-width check-info-stack))
   (define (display-check-info-with-width check-info)
     (display-check-info max-name-width check-info))
   (for-each display-check-info-with-width

--- a/rackunit-lib/rackunit/text-ui.rkt
+++ b/rackunit-lib/rackunit/text-ui.rkt
@@ -130,13 +130,15 @@
              5]))))
 
 (define (textui-display-check-info-stack stack [verbose? #f])
+  (define max-name-width (check-info-stack-max-name-width check-info-stack))
   (for-each
    (lambda (info)
      (cond
        [(check-name? info)
-        (display-check-info info)]
+        (display-check-info max-name-width info)]
        [(check-location? info)
         (display-check-info-name-value
+         max-name-width
          'location
          (trim-current-directory
           (location->string
@@ -144,16 +146,19 @@
          displayln)]
        [(check-params? info)
         (display-check-info-name-value
+         max-name-width
          'params
          (check-info-value info)
          (lambda (v) (map pretty-print v)))]
        [(check-actual? info)
         (display-check-info-name-value
+         max-name-width
          'actual
          (check-info-value info)
          pretty-print)]
        [(check-expected? info)
         (display-check-info-name-value
+         max-name-width
          'expected
          (check-info-value info)
          pretty-print)]
@@ -161,7 +166,7 @@
              (not verbose?))
         (void)]
        [else
-        (display-check-info info)]))
+        (display-check-info max-name-width info)]))
    (sort-stack
     (if verbose?
       stack

--- a/rackunit-lib/rackunit/text-ui.rkt
+++ b/rackunit-lib/rackunit/text-ui.rkt
@@ -130,7 +130,7 @@
              5]))))
 
 (define (textui-display-check-info-stack stack [verbose? #f])
-  (define max-name-width (check-info-stack-max-name-width check-info-stack))
+  (define max-name-width (check-info-stack-max-name-width stack))
   (for-each
    (lambda (info)
      (cond


### PR DESCRIPTION
This change allows for longer check-info keys. Previously there was a hard maximum of 12 spaces allotted for keys, so if a key was longer than that, it got cut off:

```
some-key:   "some-value"
some-super-l"bklajdk"
```

With this change however, long keys push the values to the right, ensuring a minimum of one space between the colon-suffixed keys and values:

```
some-key:            "some-value"
some-super-long-key: ”bklajdk"
```

The minimum of 12 characters is preserved, so when given only short keys spacing stays the same as before:

```
a:          "some-value"
b:          "some-other-value"
```
