### PR TITLE
idea: add [#:location srcloc?] optional argument to all tests

### DIFF
--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -146,31 +146,47 @@
            
            (define-syntax (name stx)
              (with-syntax
-                 ([loc (syntax->location stx)])
+                 ([default-loc (syntax->location stx)])
                (syntax-case stx ()
                  ((name actual ...)
                   (syntax/loc stx
                     (check-secret-name actual ...
-                                       #:location (quote loc)
+                                       #:location (quote default-loc)
                                        #:expression (quote (name actual ...)))))
 
                  ((name actual ... msg)
                   (syntax/loc stx
                     (check-secret-name actual ... msg
-                                       #:location (quote loc)
+                                       #:location (quote default-loc)
                                        #:expression (quote (name actual ...)))))
+
+                 ((name actual ... #:location custom-loc)
+                    (syntax/loc stx
+                      (check-secret-name actual ...
+                                         #:location (if custom-loc
+                                                      (srcloc->location custom-loc)
+                                                      (quote default-loc))
+                                         #:expression (quote (name actual ...)))))
+
+                 ((name actual ... msg #:location custom-loc)
+                    (syntax/loc stx
+                      (check-secret-name actual ... msg
+                                         #:location (if custom-loc
+                                                      (srcloc->location custom-loc)
+                                                      (quote default-loc))
+                                         #:expression (quote (name actual ...)))))
                     
                  (name
                   (identifier? #'name)
-                  (syntax/loc stx
+                  (syntax/loc stx ;;bg; TODO need to add #:location option here
                     (case-lambda
                       [(formal ...)
                        (check-secret-name formal ... 
-                                          #:location (quote loc) 
+                                          #:location (quote default-loc) 
                                           #:expression (quote (name actual ...)))]
                       [(formal ... msg)
                        (check-secret-name formal ... msg
-                                          #:location (quote loc) 
+                                          #:location (quote default-loc) 
                                           #:expression (quote (name actual ...)))]))))))
            ))))))
 

--- a/rackunit-lib/rackunit/private/location.rkt
+++ b/rackunit-lib/rackunit/private/location.rkt
@@ -21,7 +21,8 @@
  [location-span (location/c . -> . (or/c number? false/c))]
  [syntax->location (syntax? . -> . location/c)]
  [location->string (location/c . -> . string?)]
- [location->srcloc (location/c . -> . srcloc?)])
+ [location->srcloc (location/c . -> . srcloc?)]
+ [srcloc->location (srcloc? . -> . location/c)])
 
 ;; syntax->location : syntax -> location
 (define (syntax->location stx)
@@ -46,6 +47,14 @@
           (location-column location)
           (location-position location)
           (location-span location)))
+
+;; srcloc->location: srcloc -> location
+(define (srcloc->location src)
+  (list (srcloc-source src)
+        (srcloc-line src)
+        (srcloc-column src)
+        (srcloc-position src)
+        (srcloc-span src)))
 
 (define (source->string source)
   (cond


### PR DESCRIPTION
Here's a more concrete proposal building off #7.

**Goal:** give all tests an optional `#:location` argument, like what the `check-fn` has internally (except taking a `srcloc` instead of a `location`).

I really don't like adding cases to the macro... but anyway this lets me write tests like:

```
(check-true #f)
(check-true #f #:location (srcloc 1 2 3 4 5))
(check-true #f #:location #f)
```

and get nice error messages

```
raco test: (submod "check-with-loc.rkt" test)
--------------------
FAILURE
name:       check-true
location:   (#<path:/home/ben/code/racket/etc/rackunit/check-with-loc.rkt> 6 2 97 15)
expression: (check-true #f)
params:     (#f)

Check failure
--------------------
--------------------
FAILURE
name:       check-true
location:   (1 2 3 4 5)
expression: (check-true #f)
params:     (#f)

Check failure
--------------------
--------------------
FAILURE
name:       check-true
location:   (#<path:/home/ben/code/racket/etc/rackunit/check-with-loc.rkt> 8 2 163 29)
expression: (check-true #f)
params:     (#f)

Check failure
--------------------
3/3 test failures
```

Ultimately, this makes it easy to write macros like:

```
(define-syntax (check-true* stx)
  (syntax-case stx ()
   [(_ e* ...)
    #`(begin (check-true e* #:location #,(syntax->location stx)) ...)]))
```
