### PR TITLE
Adjust docs on checks and current-check-handler

### DIFF
--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -10,10 +10,10 @@
 @title{Checks}
 
 Checks are the basic building block of RackUnit.  A check
-checks some condition.  If the condition holds the check
-evaluates to @racket[(void)].  If the condition doesn't hold the
-check raises an instance of @racket[exn:test:check] with
-information detailing the failure.
+checks some condition and always
+evaluates to @racket[(void)].  If the condition doesn't hold, the
+check will report the failure (see @racket[current-check-handler]
+for customizing how failures are handled).
 
 Although checks are implemented as macros, which is
 necessary to grab source location, they are conceptually

--- a/rackunit-doc/rackunit/scribblings/internals.scrbl
+++ b/rackunit-doc/rackunit/scribblings/internals.scrbl
@@ -20,7 +20,8 @@ of these parameters.
 @defparam[current-check-handler handler (-> any/c any)]{
 
 Parameter containing the function that handles exceptions
-raised by check failures.  The default value is @racket[raise].
+raised by check failures.  The default value is a procedure
+that will display the exception data in a user-friendly format.
 }
 
 @defparam[current-check-around check (-> (-> any) any)]{


### PR DESCRIPTION
I think the current docs are misleading on checks and wrong about the default value of `current-check-handler`. This PR should fix that.

Can someone else check if these adjustments are accurate?

Prompted by http://stackoverflow.com/questions/33324304/racketunit-check-is-not-throwing-exception