### PR TITLE
Update doc for check-exn: predicate can be trueish

### DIFF
--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -109,7 +109,7 @@ For example, the following checks all fail:
          void?]{
 
 Checks that @racket[thunk] raises an exception and that either
-@racket[exn-predicate] returns @racket[#t] if it is a function, or
+@racket[exn-predicate] returns a true value if it is a function, or
 that it matches the message in the exception if @racket[exn-predicate]
 is a regexp. In the latter case, the exception raised must be an
 @racket[exn:fail?].  The optional @racket[message] is included in the


### PR DESCRIPTION
The predicate in `check-exn` is a match if it returns a true value, not just `#t`.   

``` racket
(check-exn (λ (ex) #t) (thunk (error))) ; passes
(check-exn (λ (ex) 'trueish) (thunk (error))) ; passes
```

It's a minor thing, but the difference is worth noting since there are other checks where non-`#t` means failure (the predicate in `check-match`, for example).  