### PR TITLE
make the top-level checks look more like how they look when using text-ui

### DIFF
--- a/rackunit-lib/rackunit/text-ui.rkt
+++ b/rackunit-lib/rackunit/text-ui.rkt
@@ -111,24 +111,6 @@
        (display-exn exn))]
     [else (void)]))
 
-(define (sort-stack l)
-  (sort l < 
-        #:key 
-        (λ (info)
-          (cond
-            [(check-name? info)
-             0]
-            [(check-location? info)
-             1]
-            [(check-params? info)
-             2]
-            [(check-actual? info)
-             3]
-            [(check-expected? info)
-             4]            
-            [else
-             5]))))
-
 (define (textui-display-check-info-stack stack [verbose? #f])
   (define max-name-width (check-info-stack-max-name-width stack))
   (for-each
@@ -171,31 +153,6 @@
     (if verbose?
       stack
       (strip-redundant-params stack)))))
-
-;; display-verbose-check-info : test-result -> void
-(define (display-verbose-check-info result)
-  (cond
-    ((test-failure? result)
-     (let* ((exn (test-failure-result result))
-            (stack (exn:test:check-stack exn)))
-       (for-each
-        (lambda (info)
-          (cond
-            ((check-location? info)
-             (display "location: ")
-             (display (trim-current-directory
-                       (location->string
-                        (check-info-value info)))))
-            (else
-             (display (check-info-name info))
-             (display ": ")
-             (write (check-info-value info))))
-          (newline))
-        (sort-stack stack))))
-    ((test-error? result)
-     (display-exn (test-error-result result)))
-    (else
-     (void))))
 
 (define (std-test/text-ui display-context test)
   (fold-test-results

--- a/rackunit-test/tests/rackunit/standalone.rkt
+++ b/rackunit-test/tests/rackunit/standalone.rkt
@@ -47,9 +47,9 @@ Outta here!
 --------------------
 FAILURE
 name:       check
-location:   (#<path:PLTHOME/collects/tests/rackunit/standalone-check-test.rkt> 48 0 1450 17)
-expression: (check = 1 2)
-params:     (#<procedure:=> 1 2)\nmessage:    0.0
+location:   standalone-check-test.rkt:48:0
+params:     (#<procedure:=> 1 2)
+message:    0.0
 
 Check failure
 --------------------
@@ -71,22 +71,20 @@ Second Outta here!
 --------------------
 --------------------
 FAILURE
+name:       check-eq?
+location:   standalone-test-case-test.rkt:23:12
 actual:     1
 expected:   2
-name:       check-eq?
-location:   (#<path:PLTHOME/collects/tests/rackunit/standalone-test-case-test.rkt> 23 12 626 15)
-expression: (check-eq? 1 2)
 
 Check failure
 --------------------
 --------------------
 failure
 FAILURE
+name:       check-eq?
+location:   standalone-test-case-test.rkt:24:21
 actual:     1
 expected:   2
-name:       check-eq?
-location:   (#<path:PLTHOME/collects/tests/rackunit/standalone-test-case-test.rkt> 24 21 664 15)
-expression: (check-eq? 1 2)
 
 Check failure
 --------------------


### PR DESCRIPTION

Or, in other words, try to make these two print similarly:

  #lang racket
  (require rackunit rackunit/text-ui)
  (check-equal? 1 2)
  (run-tests (test-suite "name" (check-equal? 1 2)))