### PR TITLE
Use define-runtime-path for the rackunit screenshot.

### DIFF
--- a/rackunit-doc/rackunit/scribblings/ui.scrbl
+++ b/rackunit-doc/rackunit/scribblings/ui.scrbl
@@ -38,6 +38,8 @@ information.
 RackUnit also provides a GUI test runner, available from the
 @racketmodname[rackunit/gui] module.
 
+@define-runtime-path[scribblings/rackunit-screen-shot.png
+                     "scribblings/rackunit-screen-shot.png"]
 @defproc[(test/gui [test (or/c test-case? test-suite?)] ...
                    [#:wait? wait? boolean? #f])
          void?]{
@@ -66,7 +68,7 @@ the test runner window has been closed.
     (test-case "append" (check-equal? (string-append "a" "b") "ab"))
     (test-case "ref" (check-equal? (string-ref "abc" 1) #\b)))))]
 
- @image["scribblings/rackunit-screen-shot.png"]{Screenshot of the RackUnit
+ @image[scribblings/rackunit-screen-shot.png]{Screenshot of the RackUnit
   window. It features a tree representing the nested test suites (with test
   cases as leaves) on the left pane, and information about the selected test
   failure in the right pane.}


### PR DESCRIPTION
I just realized that images included with an immediate path in scribble can cause problems when the document is incuded via `@include-section` into a document in another package. This is unlikely to happen, but to be on the safe side this patch uses `define-runtime-path`.

Can someone who is more familiar with scribble confirm that this is the correct fix / best practice?