### PR TITLE
Omit check failure message when custom message not provided.

### DIFF
--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -72,7 +72,7 @@
          marks
          (check-info-stack marks)))))
     ((_)
-     (fail-check "Check failure"))))
+     (fail-check ""))))
 
 (define-syntax fail-internal
   (syntax-rules ()

--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -38,7 +38,7 @@
 ;; parameter current-check-handler : (-> any any)
 (define current-check-handler
   (make-parameter
-   (λ (e) (display-test-failure/error e))
+   display-test-failure/error
    (lambda (v)
      (if (procedure? v)
          v

--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -35,14 +35,10 @@
          check-match
          fail)
 
-;; default-check-handler : any -> any
-(define (default-check-handler e)
-  (display-test-failure/error e))
-
 ;; parameter current-check-handler : (-> any any)
 (define current-check-handler
   (make-parameter
-   default-check-handler
+   (λ (e) (display-test-failure/error e))
    (lambda (v)
      (if (procedure? v)
          v
@@ -53,15 +49,10 @@
   (with-handlers ([(lambda (e) #t) (current-check-handler)])
     (thunk)))
 
-;; top-level-check-around : ( -> a) -> a
-(define (top-level-check-around thunk)
-  (check-around thunk)
-  (void))
-
 ;; parameter current-check-around : (( -> a) -> a)
 (define current-check-around
   (make-parameter
-   top-level-check-around
+   (λ (thunk) (check-around thunk) (void))
    (lambda (v)
      (if (procedure? v)
          v

--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -130,7 +130,7 @@
                                       (list (make-check-message message))
                                       null))
                              (lambda () (begin0 (let () body ...) (test-log! #t))))))
-                       
+
                        ;; All checks should return (void).
                        (void)))]
                    [check-secret-name (datum->syntax stx (gensym (syntax->datum (syntax name))))])
@@ -142,7 +142,7 @@
            ;; received from Ryan Culpepper.
 
            (define check-secret-name check-fn)
-           
+
            (define-syntax (name stx)
              (with-syntax ([loc (datum->syntax #f 'loc stx)])
                (syntax-case stx ()
@@ -157,13 +157,13 @@
                     (check-secret-name actual ... msg
                                        #:location (syntax->location (quote-syntax loc))
                                        #:expression (quote (name actual ...)))))
-                    
+
                  (name
                   (identifier? #'name)
                   (syntax/loc stx
                     (case-lambda
                       [(formal ...)
-                       (check-secret-name formal ... 
+                       (check-secret-name formal ...
                                           #:location (syntax->location (quote-syntax loc))
                                           #:expression (quote (name actual ...)))]
                       [(formal ... msg)
@@ -315,4 +315,3 @@
                        [_ #f]))))))]
     [(_ actual expected)
      (syntax/loc stx (check-match actual expected #t))]))
-

--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -101,8 +101,7 @@
 ;; display-check-info-stack : (listof check-info) -> void
 (define (display-check-info-stack check-info-stack)
   (display-verbose-check-info-stack
-   (strip-redundant-params check-info-stack))
-  (newline))
+   (strip-redundant-params check-info-stack)))
 
 ;; display-test-name : (U string #f) -> void
 (define (display-test-name name)
@@ -158,8 +157,9 @@
     (cond [(exn:test:check? e)
            (display-failure) (newline)
            (display-check-info-stack (exn:test:check-stack e))
-           (when #t
-             (parameterize ((error-print-context-length 0))
+           (unless (equal? (exn-message e) "")
+             (newline)
+             (parameterize ([error-print-context-length 0])
                ((error-display-handler) (exn-message e) e)))]
           [else
            (display-error) (newline)

--- a/rackunit-test/tests/rackunit/format-test.rkt
+++ b/rackunit-test/tests/rackunit/format-test.rkt
@@ -20,5 +20,5 @@
                              (make-check-actual 1)
                              (make-check-expected 2)))
                       (get-output-string p))
-               "name:       \"foo\"\nactual:     1\nexpected:   2\n\n"))))
+               "name:       \"foo\"\nactual:     1\nexpected:   2\n"))))
    ))


### PR DESCRIPTION
Closes #11 

After this change, the expression `(check-equal? 1 2)` prints an error message like this:

```
--------------------
FAILURE
name:       check-equal?
location:   unsaved-editor:3:0
actual:     1
expected:   2
expression: (check-equal? 1 2)
--------------------
```

A mild refactoring in `check.rkt` involving wrapper functions is included.