### PR TITLE
Add string-info wrapper for info messages

### DIFF
--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -267,7 +267,7 @@ the @racket[with-check-info*] function, and the
 @racket[with-check-info] macro.
 
 @defstruct[check-info ([name symbol?] [value any])]{
- A check-info structure stores information associated with the context of
+ A check-info structure stores information associated with the context of the
  execution of a check. The @racket[value] is written in a check failure message
  using @racket[write] unless it is a @racket[string-info] value.}
 

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -279,7 +279,8 @@ the @racket[with-check-info*] function, and the
    #:eval rackunit-eval
    (with-check-info (['value "hello world"]
                      ['message (string-info "hello world")])
-     (check = 1 2)))}
+     (check = 1 2)))
+ @history[#:added "1.2"]}
 
 The are several predefined functions that create check
 information structures with predefined names.  This avoids

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -267,9 +267,19 @@ the @racket[with-check-info*] function, and the
 @racket[with-check-info] macro.
 
 @defstruct[check-info ([name symbol?] [value any])]{
+ A check-info structure stores information associated with the context of
+ execution of a check. The @racket[value] is written in a check failure message
+ using @racket[write] unless it is a @racket[string-info] value.}
 
-A check-info structure stores information associated
-with the context of execution of a check.}
+@defstruct*[string-info ([value string?])]{
+ A special wrapper around a string for use as a @racket[check-info] value. When
+ displayed in a check failure message, @racket[value] is displayed without
+ quotes. Used to print messages in check infos instead of writing values.
+ @(interaction
+   #:eval rackunit-eval
+   (with-check-info (['value "hello world"]
+                     ['message (string-info "hello world")])
+     (check = 1 2)))}
 
 The are several predefined functions that create check
 information structures with predefined names.  This avoids

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -120,13 +120,13 @@ that checks are conceptually functions.
 For example, the following checks succeed:
 
 @interaction[#:eval rackunit-eval
-  (check-exn 
-   exn:fail? 
+  (check-exn
+   exn:fail?
    (lambda ()
      (raise (make-exn:fail "Hi there"
                            (current-continuation-marks)))))
-  (check-exn 
-   exn:fail? 
+  (check-exn
+   exn:fail?
    (lambda ()
      (error 'hi "there")))
 ]
@@ -288,7 +288,7 @@ misspelling errors:
 
 @defproc*[([(make-check-name (name string?)) check-info?]
            [(make-check-params (params (listof any))) check-info?]
-           [(make-check-location (loc (list/c any (or/c number? #f) (or/c number? #f) 
+           [(make-check-location (loc (list/c any (or/c number? #f) (or/c number? #f)
                                                   (or/c number? #f) (or/c number? #f))))
             check-info?]
            [(make-check-expression (msg any)) check-info?]
@@ -386,7 +386,7 @@ We can use these checks in the usual way:
 
 @interaction[#:eval rackunit-eval
   (check-odd? 3)
-  (check-odd? 2) 
+  (check-odd? 2)
 ]
 
 @defform*[[(define-binary-check (name pred actual expected))

--- a/rackunit-lib/info.rkt
+++ b/rackunit-lib/info.rkt
@@ -12,4 +12,4 @@
 
 (define pkg-authors '(ryanc noel))
 
-(define version "1.1")
+(define version "1.2")

--- a/rackunit-lib/rackunit/private/check-info.rkt
+++ b/rackunit-lib/rackunit/private/check-info.rkt
@@ -1,21 +1,32 @@
 #lang racket/base
 (require racket/contract/base
+         racket/port
          "location.rkt"
          (for-syntax racket/base
                      racket/syntax))
+
+(provide
+ (contract-out
+  [struct check-info ([name symbol?]
+                      [value any/c])]
+  [struct string-info ([value string?])]
+  [info-value->string (-> any/c string?)]
+  [check-info-mark symbol?]
+  [check-info-stack (continuation-mark-set? . -> . (listof check-info?))]
+  [with-check-info* ((listof check-info?) (-> any) . -> . any)])
+ with-check-info)
 
 ;; Structures --------------------------------------------------
 
 ;; struct check-info : symbol any
 (define-struct check-info (name value))
 
-(provide/contract
- [struct check-info ([name symbol?]
-                     [value any/c])]
- [check-info-mark symbol?]
- [check-info-stack (continuation-mark-set? . -> . (listof check-info?))]
- [with-check-info* ((listof check-info?) (-> any) . -> . any)])
-(provide with-check-info)
+(struct string-info (value) #:transparent)
+
+(define (info-value->string info-value)
+  (if (string-info? info-value)
+      (string-info-value info-value)
+      (with-output-to-string (λ () (write info-value)))))
 
 ;; Infrastructure ----------------------------------------------
 

--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -50,7 +50,13 @@
    (symbol->string
     (check-info-name check-info))))
 
-(define (display-check-info-name-value max-name-width name value [value-printer (lambda (x) (write x) (newline))])
+(define (print-info-value v)
+  (displayln (info-value->string v)))
+
+(define (display-check-info-name-value max-name-width
+                                       name
+                                       value
+                                       [value-printer print-info-value])
   (display (string-pad-right
             (string-append (symbol->string name) ": ")
             (max minimum-name-width (+ max-name-width 2))))

--- a/rackunit-lib/rackunit/private/test.rkt
+++ b/rackunit-lib/rackunit/private/test.rkt
@@ -18,6 +18,7 @@
          (struct-out test-success)
          (struct-out rackunit-test-case)
          (struct-out rackunit-test-suite)
+         (struct-out string-info)
 
          with-check-info
          with-check-info*


### PR DESCRIPTION
Closes #26

With this change, it’s now possible for a check info value to print a message without quotes by wrapping the value string in a call to `string-info`. See the example added to the docs.