### PR TITLE
Remove unnecessary data-lib dependencies

### DIFF
--- a/rackunit-lib/info.rkt
+++ b/rackunit-lib/info.rkt
@@ -3,7 +3,6 @@
 (define collection 'multi)
 
 (define deps '("base"
-               "data-lib"
                "testing-util-lib"))
 
 (define implies '("testing-util-lib"))

--- a/rackunit-plugin-lib/info.rkt
+++ b/rackunit-plugin-lib/info.rkt
@@ -3,7 +3,6 @@
 (define collection 'multi)
 
 (define deps '("base"
-               "data-lib"
                "rackunit-lib"
                "rackunit-gui"
                "gui-lib"


### PR DESCRIPTION
Only legitimate use seems to be in the rackunit-gui-lib package.