### PR TITLE
Fix check failure message tests

### DIFF
--- a/rackunit-test/tests/rackunit/standalone.rkt
+++ b/rackunit-test/tests/rackunit/standalone.rkt
@@ -51,8 +51,6 @@ location:   standalone-check-test.rkt:48:0
 params:     (#<procedure:=> 1 2)
 expression: (check = 1 2)
 message:    0.0
-
-Check failure
 --------------------
 ")
 
@@ -77,8 +75,6 @@ location:   standalone-test-case-test.rkt:23:12
 actual:     1
 expected:   2
 expression: (check-eq? 1 2)
-
-Check failure
 --------------------
 --------------------
 failure
@@ -88,7 +84,5 @@ location:   standalone-test-case-test.rkt:24:21
 actual:     1
 expected:   2
 expression: (check-eq? 1 2)
-
-Check failure
 --------------------
 ")


### PR DESCRIPTION
#25 failed to properly update the tests and caused a [DrDr failure](http://drdr.racket-lang.org/40705/racket/share/pkgs/rackunit-test/tests/rackunit/standalone.rkt).