### PR TITLE
Add a verbose-info type

### DIFF
--- a/rackunit-lib/rackunit/private/check-info.rkt
+++ b/rackunit-lib/rackunit/private/check-info.rkt
@@ -14,6 +14,7 @@
   [struct string-info ([value string?])]
   [struct location-info ([value location/c])]
   [struct pretty-info ([value any/c])]
+  [struct verbose-info ([value any/c])]
   [info-value->string (-> any/c string?)]
   [current-check-info (parameter/c (listof check-info?))]
   [with-check-info* ((listof check-info?) (-> any) . -> . any)])
@@ -30,6 +31,7 @@
 (struct string-info (value) #:transparent)
 (struct location-info (value) #:transparent)
 (struct pretty-info (value) #:transparent)
+(struct verbose-info (value) #:transparent)
 
 (define (info-value->string info-value)
   (cond
@@ -38,6 +40,8 @@
      (trim-current-directory
       (location->string (location-info-value info-value)))]
     [(pretty-info? info-value) (pretty-format (pretty-info-value info-value))]
+    [(verbose-info? info-value)
+     (info-value->string (verbose-info-value info-value))]
     [else (~s info-value)]))
 
 (define (trim-current-directory path)
@@ -79,7 +83,7 @@
 (define-check-type name any/c)
 (define-check-type params any/c #:wrapper pretty-info)
 (define-check-type location location/c #:wrapper location-info)
-(define-check-type expression any/c)
+(define-check-type expression any/c #:wrapper verbose-info)
 (define-check-type message any/c)
 (define-check-type actual any/c #:wrapper pretty-info)
 (define-check-type expected any/c #:wrapper pretty-info)

--- a/rackunit-lib/rackunit/text-ui.rkt
+++ b/rackunit-lib/rackunit/text-ui.rkt
@@ -79,28 +79,13 @@
     [(test-failure? result)
      (let* ([exn (test-failure-result result)]
             [stack (exn:test:check-stack exn)])
-       (textui-display-check-info-stack stack verbose?)
+       (display-check-info-stack stack #:verbose? verbose?)
        (parameterize ([error-print-context-length 0])
          ((error-display-handler) (exn-message exn) exn)))]
     [(test-error? result)
      (let ([exn (test-error-result result)])
        (display-exn exn))]
     [else (void)]))
-
-(define (textui-display-check-info-stack stack [verbose? #f])
-  (define max-name-width (check-info-stack-max-name-width stack))
-  (for-each
-   (lambda (info)
-     (cond
-       [(and (check-expression? info)
-             (not verbose?))
-        (void)]
-       [else
-        (display-check-info max-name-width info)]))
-   (sort-stack
-    (if verbose?
-        stack
-        (strip-redundant-params stack)))))
 
 (define (std-test/text-ui display-context test)
   (fold-test-results

--- a/rackunit-test/tests/rackunit/standalone.rkt
+++ b/rackunit-test/tests/rackunit/standalone.rkt
@@ -49,7 +49,6 @@ FAILURE
 name:       check
 location:   standalone-check-test.rkt:48:0
 params:     '(#<procedure:=> 1 2)
-expression: (check = 1 2)
 message:    0.0
 --------------------
 ")
@@ -74,7 +73,6 @@ name:       check-eq?
 location:   standalone-test-case-test.rkt:23:12
 actual:     1
 expected:   2
-expression: (check-eq? 1 2)
 --------------------
 --------------------
 failure
@@ -83,6 +81,5 @@ name:       check-eq?
 location:   standalone-test-case-test.rkt:24:21
 actual:     1
 expected:   2
-expression: (check-eq? 1 2)
 --------------------
 ")


### PR DESCRIPTION
This lets RackUnit mark some info types as “verbose only”, and they’ll
only show up when run-tests is used in ‘verbose mode. Normal checks
evaluated in DrRacket won’t show verbose info.

The only info type marked as verbose is `expression` which is typically
redundant in DrRacket, since the check failure message is supposed to
have an exception srcloc pointing to the failure expression. Checks run
in CI or from the command line won’t show the expression, but the error
message does already include the file and line number.

This does not expose the verbose-info struct to RackUnit users.
Instead, it is used internally to remove the now-redundant verbose-info
logic in rackunit/text-ui. With this change, rackunit/text-ui and
normal check evaluation are at “feature parity” in terms of how they
treat check failures, and the run-tests implementation can be stripped
down and the monad logic removed (see #35).