### PR TITLE
Fix missing calls to error-display-handler for checks without failure messages

### DIFF
--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -113,7 +113,7 @@
       (when (not (equal? (exn-message v) ""))
         (newline)
         (displayln (exn-message v)))
-      (printf "A value other than an exception was raised: ~e\n" v)))
+      (printf "\nA value other than an exception was raised: ~e\n" v)))
 
 (define (display-delimiter) (displayln "--------------------"))
 

--- a/rackunit-test/tests/rackunit/standalone.rkt
+++ b/rackunit-test/tests/rackunit/standalone.rkt
@@ -41,8 +41,8 @@
            #"\
 --------------------
 ERROR
-Outta here!
 
+Outta here!
 --------------------
 --------------------
 FAILURE
@@ -58,14 +58,14 @@ message:    0.0
            #"\
 --------------------
 ERROR
-First Outta here!
 
+First Outta here!
 --------------------
 --------------------
 error
 ERROR
-Second Outta here!
 
+Second Outta here!
 --------------------
 --------------------
 FAILURE


### PR DESCRIPTION
Closes #42 

Not using `error-display-handler` causes DrRacket to lose the clickable “stop signs” in check failures that points to the check’s location; this adds back the missing calls. Also, cleans up the failure printing logic a bit since that can now be safely done without messing up `rackunit/text-ui`.

cc @AlexKnauth 