### PR TITLE
Remove check info stack sorting

### DIFF
--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -73,7 +73,7 @@
   (define stack
     (if verbose? check-info-stack (simplify-params check-info-stack)))
   (define max-name-width (check-info-stack-max-name-width stack))
-  (for ([info (in-list (sort-stack stack))])
+  (for ([info (in-list stack)])
     (display-check-info-name-value max-name-width
                                    (check-info-name info)
                                    (check-info-value info))))
@@ -122,21 +122,3 @@
       (parameterize ([error-print-context-length 0])
         ((error-display-handler) desc raised-value))
       (displayln desc)))
-
-(define (sort-stack l)
-  (sort l <
-        #:key
-        (λ (info)
-          (cond
-            [(check-name? info)
-             0]
-            [(check-location? info)
-             1]
-            [(check-params? info)
-             2]
-            [(check-actual? info)
-             3]
-            [(check-expected? info)
-             4]
-            [else
-             5]))))

--- a/rackunit-test/tests/rackunit/all-rackunit-tests.rkt
+++ b/rackunit-test/tests/rackunit/all-rackunit-tests.rkt
@@ -2,7 +2,6 @@
 
 (require rackunit
          "check-test.rkt"
-         "check-info-test.rkt"
          "format-test.rkt"
          "test-case-test.rkt"
          "test-suite-test.rkt"
@@ -21,7 +20,6 @@
    "All RackUnit Tests"
    check-tests
    base-tests
-   check-info-tests
    test-case-tests
    test-suite-tests
    test-suite-define-provide-test

--- a/rackunit-test/tests/rackunit/check-info-test.rkt
+++ b/rackunit-test/tests/rackunit/check-info-test.rkt
@@ -31,70 +31,68 @@
          rackunit/private/check-info
          (submod rackunit/private/check-info for-test))
 
-(provide check-info-tests)
+(module+ test
+  (test-case "with-check-info stores value in lexical order"
+    (define stack
+      (with-check-info (['a 1] ['b 2] ['c 3]) (current-check-info)))
+    (for ([actual (in-list stack)]
+          [expected (in-list (list 'a 'b 'c))])
+      (check-eq? (check-info-name actual) expected)))
 
-(define check-info-tests
-  (test-suite "All check-info tests"
-              (test-case
-               "with-check-info stores value in lexical order"
-               (let ((stack (with-check-info
-                             (('a 1)
-                              ('b 2)
-                              ('c 3))
-                             (current-check-info))))
-                 (for-each (lambda (actual expected)
-                             (check-eq? (check-info-name actual)
-                                        expected))
-                           stack
-                           (list 'a 'b 'c))))
-              
-              (test-case
-               "Nested uses of with-check-info store values in lexical order"
-               (let ((stack (with-check-info
-                             (('a 1)
-                              ('b 2)
-                              ('c 3))
-                             (with-check-info
-                              (('d 4)
-                               ('e 5)
-                               ('f 6))
-                              (current-check-info)))))
-                 (for-each (lambda (actual expected)
-                             (check-eq? (check-info-name actual)
-                                        expected))
-                           stack
-                           (list 'a 'b 'c 'd 'e 'f))))
-              
-              (test-case
-               "check-actual? and check-expected? work"
-               (check-true (check-actual? (make-check-actual 1)))
-               (check-true (check-expected? (make-check-expected 1)))
-               (check-false (check-expected? (make-check-actual 1)))
-               (check-false (check-expected? (make-check-actual 1))))
-              
-              (test-case
-               "make-check-actual and make-check-expected store param (prettified)"
-               (check-equal? (check-info-value (make-check-actual 1))
-                             (pretty-info 1))
-               (check-equal? (check-info-value (make-check-expected 2))
-                             (pretty-info 2)))
+  (test-case "Nested uses of with-check-info store values in lexical order"
+    (define stack
+      (with-check-info (['a 1] ['b 2] ['c 3])
+        (with-check-info (['d 4] ['e 5] ['f 6])
+          (current-check-info))))
+    (for ([actual (in-list stack)]
+          [expected (in-list (list 'a 'b 'c 'd 'e 'f))])
+      (check-eq? (check-info-name actual) expected)))
 
-              (test-suite
-               "All tests for trim-current-directory"
-   
-               (test-equal?
-                "trim-current-directory leaves directories outside the current directory alone"
-                (trim-current-directory "/foo/bar/")
-                "/foo/bar/")
-   
-               (test-equal?
-                "trim-current-directory strips directory from files in current directory"
-                (trim-current-directory
-                 (path->string (build-path (current-directory) "foo.rkt")))
-                "foo.rkt")
-   
-               (test-equal?
-                "trim-current-directory leaves subdirectories alone"
-                (trim-current-directory
-                 (path->string (build-path (current-directory) "foo" "bar.rkt")))
-                "foo/bar.rkt"))))
+  (test-case "check-actual? and check-expected? work"
+    (check-true (check-actual? (make-check-actual 1)))
+    (check-true (check-expected? (make-check-expected 1)))
+    (check-false (check-expected? (make-check-actual 1)))
+    (check-false (check-expected? (make-check-actual 1))))
+
+  (test-case "make-check-actual and make-check-expected store param (prettified)"
+    (check-equal? (check-info-value (make-check-actual 1)) (pretty-info 1))
+    (check-equal? (check-info-value (make-check-expected 2)) (pretty-info 2)))
+
+  (test-case "define-check adds certain infos automatically in a specific order"
+    (define current-info-box (make-parameter #f))
+    (define-check (check-foo arg1 arg2 arg3)
+      (set-box! (current-info-box) (current-check-info)))
+    (define (get-foo-info-names)
+      (parameterize ([current-info-box (box 'uninitialized)])
+        (check-foo 'arg1 'arg2 'arg3)
+        (map check-info-name (unbox (current-info-box)))))
+    (define expected-info-names
+      (list 'name 'location 'expression 'params))
+    (check-equal? (get-foo-info-names) expected-info-names))
+
+  (test-case "define-check infos are added before custom infos"
+    (define current-info-box (make-parameter #f))
+    (define-check (check-foo/custom-info arg1 arg2 arg3)
+      (with-check-info (['custom1 'foo] ['custom2 'bar])
+        (set-box! (current-info-box) (current-check-info))))
+    (define (get-foo-info-names)
+      (parameterize ([current-info-box (box 'uninitialized)])
+        (check-foo/custom-info 'arg1 'arg2 'arg3)
+        (map check-info-name (unbox (current-info-box)))))
+    (define expected-info-names
+      (list 'name 'location 'expression 'params 'custom1 'custom2))
+    (check-equal? (get-foo-info-names) expected-info-names))
+
+  (test-case "All tests for trim-current-directory"
+    (test-case "trim-current-directory leaves directories outside the current directory alone"
+      (check-equal? (trim-current-directory "/foo/bar/") "/foo/bar/"))
+    (test-equal?
+     "trim-current-directory strips directory from files in current directory"
+     (trim-current-directory
+      (path->string (build-path (current-directory) "foo.rkt")))
+     "foo.rkt")
+    (test-equal?
+     "trim-current-directory leaves subdirectories alone"
+     (trim-current-directory
+      (path->string (build-path (current-directory) "foo" "bar.rkt")))
+     "foo/bar.rkt")))


### PR DESCRIPTION
The new parameter representation of infos ensures that the built-in
`define-check` infos appear in order before any user-added infos. The
one exception is that the `expression` info now appears before the
`actual` or `expected` infos, but since it’s only present in verbose
mode I don’t think that’s much of an issue.