### PR TITLE
Add nested-info

### DIFF
--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -269,7 +269,8 @@ the @racket[with-check-info*] function, and the
 @defstruct[check-info ([name symbol?] [value any]) #:transparent]{
  A check-info structure stores information associated with the context of the
  execution of a check. The @racket[value] is written in a check failure message
- using @racket[write] unless it is a @racket[string-info] value.
+ using @racket[write] unless it is a @racket[string-info] value or a
+ @racket[nested-info] value.
  @history[#:changed "1.6" "Changed from opaque to transparent"]}
 
 @defstruct*[string-info ([value string?])]{
@@ -278,10 +279,29 @@ the @racket[with-check-info*] function, and the
  quotes. Used to print messages in check infos instead of writing values.
  @(interaction
    #:eval rackunit-eval
-   (with-check-info (['value "hello world"]
-                     ['message (string-info "hello world")])
-     (check = 1 2)))
+   (define-check (string-info-check)
+     (with-check-info (['value "hello world"]
+                       ['message (string-info "hello world")])
+       (fail-check)))
+   (string-info-check))
  @history[#:added "1.2"]}
+
+@deftogether[
+ ((defproc (nested-info [info check-info?] ...) nested-info?)
+  (defproc (nested-info? [v any/c]) boolean?)
+  (defproc (nested-info-values [nested nested-info?]) (listof check-info?)))]{
+ A special wrapper around a list of infos for use as a @racket[check-info]
+ value. A check info whose value is a nested info is displayed as an indented
+ sub-list of infos. Nested infos can be placed inside nested infos, yielding
+ greater indentation.
+ @(interaction
+   #:eval rackunit-eval
+   (define-check (nested-info-check)
+     (define nested
+       (nested-info (make-check-info 'foo "foo") (make-check-info 'bar "bar")))
+     (with-check-info (['nested nested]) (fail-check)))
+   (nested-info-check))
+ @history[#:added "1.7"]}
 
 The are several predefined functions that create check
 information structures with predefined names.  This avoids

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -273,7 +273,7 @@ the @racket[with-check-info*] function, and the
  @racket[nested-info] value.
  @history[#:changed "1.6" "Changed from opaque to transparent"]}
 
-@defstruct*[string-info ([value string?])]{
+@defstruct*[string-info ([value string?]) #:transparent]{
  A special wrapper around a string for use as a @racket[check-info] value. When
  displayed in a check failure message, @racket[value] is displayed without
  quotes. Used to print messages in check infos instead of writing values.
@@ -286,10 +286,7 @@ the @racket[with-check-info*] function, and the
    (string-info-check))
  @history[#:added "1.2"]}
 
-@deftogether[
- ((defproc (nested-info [info check-info?] ...) nested-info?)
-  (defproc (nested-info? [v any/c]) boolean?)
-  (defproc (nested-info-values [nested nested-info?]) (listof check-info?)))]{
+@defstruct*[nested-info ([values (listof check-info?)]) #:transparent]{
  A special wrapper around a list of infos for use as a @racket[check-info]
  value. A check info whose value is a nested info is displayed as an indented
  sub-list of infos. Nested infos can be placed inside nested infos, yielding
@@ -297,9 +294,9 @@ the @racket[with-check-info*] function, and the
  @(interaction
    #:eval rackunit-eval
    (define-check (nested-info-check)
-     (define nested
-       (nested-info (make-check-info 'foo "foo") (make-check-info 'bar "bar")))
-     (with-check-info (['nested nested]) (fail-check)))
+     (define infos
+       (list (make-check-info 'foo "foo") (make-check-info 'bar "bar")))
+     (with-check-info (['nested (nested-info infos)]) (fail-check)))
    (nested-info-check))
  @history[#:added "1.7"]}
 

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -289,7 +289,7 @@ the @racket[with-check-info*] function, and the
 @defstruct*[nested-info ([values (listof check-info?)]) #:transparent]{
  A special wrapper around a list of infos for use as a @racket[check-info]
  value. A check info whose value is a nested info is displayed as an indented
- sub-list of infos. Nested infos can be placed inside nested infos, yielding
+ subsequence of infos. Nested infos can be placed inside nested infos, yielding
  greater indentation.
  @(interaction
    #:eval rackunit-eval

--- a/rackunit-lib/info.rkt
+++ b/rackunit-lib/info.rkt
@@ -11,4 +11,4 @@
 
 (define pkg-authors '(ryanc noel))
 
-(define version "1.6")
+(define version "1.7")

--- a/rackunit-lib/rackunit/private/check-info.rkt
+++ b/rackunit-lib/rackunit/private/check-info.rkt
@@ -14,6 +14,9 @@
   [struct string-info ([value string?])]
   [struct location-info ([value location/c])]
   [struct pretty-info ([value any/c])]
+  [nested-info (->* () #:rest list? nested-info?)]
+  [nested-info? predicate/c]
+  [nested-info-values (-> nested-info? list?)]
   [struct verbose-info ([value any/c])]
   [info-value->string (-> any/c string?)]
   [current-check-info (parameter/c (listof check-info?))]
@@ -32,6 +35,10 @@
 (struct location-info (value) #:transparent)
 (struct pretty-info (value) #:transparent)
 (struct verbose-info (value) #:transparent)
+(struct nested-info (values)
+  #:transparent #:omit-define-syntaxes #:constructor-name make-nested-info)
+
+(define (nested-info . vs) (make-nested-info vs))
 
 (define (info-value->string info-value)
   (cond

--- a/rackunit-lib/rackunit/private/check-info.rkt
+++ b/rackunit-lib/rackunit/private/check-info.rkt
@@ -14,9 +14,7 @@
   [struct string-info ([value string?])]
   [struct location-info ([value location/c])]
   [struct pretty-info ([value any/c])]
-  [nested-info (->* () #:rest list? nested-info?)]
-  [nested-info? predicate/c]
-  [nested-info-values (-> nested-info? list?)]
+  [struct nested-info ([values (listof check-info?)])]
   [struct verbose-info ([value any/c])]
   [info-value->string (-> any/c string?)]
   [current-check-info (parameter/c (listof check-info?))]
@@ -35,10 +33,7 @@
 (struct location-info (value) #:transparent)
 (struct pretty-info (value) #:transparent)
 (struct verbose-info (value) #:transparent)
-(struct nested-info (values)
-  #:transparent #:omit-define-syntaxes #:constructor-name make-nested-info)
-
-(define (nested-info . vs) (make-nested-info vs))
+(struct nested-info (values) #:transparent)
 
 (define (info-value->string info-value)
   (cond

--- a/rackunit-lib/rackunit/private/test.rkt
+++ b/rackunit-lib/rackunit/private/test.rkt
@@ -20,6 +20,10 @@
          (struct-out rackunit-test-suite)
          (struct-out string-info)
 
+         nested-info
+         nested-info?
+         nested-info-values
+
          with-check-info
          with-check-info*
 

--- a/rackunit-test/tests/rackunit/nested-info-test.rkt
+++ b/rackunit-test/tests/rackunit/nested-info-test.rkt
@@ -1,0 +1,44 @@
+#lang racket/base
+
+(module+ test
+
+  (require racket/function
+           racket/port
+           rackunit
+           (submod rackunit/private/format for-test))
+
+  (define-check (check-info-stack-output str-or-rx stack)
+    (define actual
+      (with-output-to-string (thunk (display-check-info-stack stack))))
+    (with-check-info (['actual actual] ['expected str-or-rx])
+      (cond
+        [(string? str-or-rx) (unless (equal? str-or-rx actual) (fail-check))]
+        [(regexp? str-or-rx)
+         (unless (regexp-match? str-or-rx actual) (fail-check))])))
+
+  (test-case "Nested check info printing"
+    (define test-info
+      (list (make-check-info 'foo 1)
+            (make-check-info 'nested
+                             (nested-info (make-check-info 'bar 2)
+                                          (make-check-info 'baz 3)))))
+    (define expected-str "foo:        1
+nested:
+  bar:        2
+  baz:        3
+")
+    (check-info-stack-output expected-str test-info))
+  (test-case "Double-nested check info printing"
+    (define test-info
+      (list
+       (make-check-info
+        'nested (nested-info
+                 (make-check-info
+                  'double-nested (nested-info (make-check-info 'foo 1)
+                                              (make-check-info 'bar 2)))))))
+    (define expected-str "nested:
+  double-nested:
+    foo:            1
+    bar:            2
+")
+    (check-info-stack-output expected-str test-info)))

--- a/rackunit-test/tests/rackunit/nested-info-test.rkt
+++ b/rackunit-test/tests/rackunit/nested-info-test.rkt
@@ -15,7 +15,7 @@
       (make-check-info (vector-ref vec name-idx) (vector-ref vec v-idx))))
 
   (define (nested-info* . name+vs) (nested-info (apply info* name+vs)))
-  
+
   (define-check (check-info-stack-output str-or-rx stack)
     (define actual
       (with-output-to-string (thunk (display-check-info-stack stack))))
@@ -30,6 +30,7 @@ nested:
   baz:        3
 ")
     (check-info-stack-output expected-str test-info))
+
   (test-case "Double-nested check info printing"
     (define test-info
       (info* 'nested
@@ -38,5 +39,20 @@ nested:
   double-nested:
     foo:            1
     bar:            2
+")
+    (check-info-stack-output expected-str test-info))
+
+  (test-case "Multiple double-nested check info printing"
+    (define test-info
+      (info* 'nested
+             (nested-info* 'foo (nested-info* 'foo1 1 'foo2 2)
+                           'bar (nested-info* 'bar1 1 'bar2 2))))
+    (define expected-str "nested:
+  foo:
+    foo1:       1
+    foo2:       2
+  bar:
+    bar1:       1
+    bar2:       2
 ")
     (check-info-stack-output expected-str test-info)))

--- a/rackunit-test/tests/rackunit/nested-info-test.rkt
+++ b/rackunit-test/tests/rackunit/nested-info-test.rkt
@@ -7,21 +7,23 @@
            rackunit
            (submod rackunit/private/format for-test))
 
+  (define (info* . name+vs)
+    (define vec (list->vector name+vs))
+    (define len (vector-length vec))
+    (for/list ([name-idx (in-range 0 len 2)]
+               [v-idx (in-range 1 len 2)])
+      (make-check-info (vector-ref vec name-idx) (vector-ref vec v-idx))))
+
+  (define (nested-info* . name+vs) (nested-info (apply info* name+vs)))
+  
   (define-check (check-info-stack-output str-or-rx stack)
     (define actual
       (with-output-to-string (thunk (display-check-info-stack stack))))
     (with-check-info (['actual actual] ['expected str-or-rx])
-      (cond
-        [(string? str-or-rx) (unless (equal? str-or-rx actual) (fail-check))]
-        [(regexp? str-or-rx)
-         (unless (regexp-match? str-or-rx actual) (fail-check))])))
+      (unless (equal? str-or-rx actual) (fail-check))))
 
   (test-case "Nested check info printing"
-    (define test-info
-      (list (make-check-info 'foo 1)
-            (make-check-info 'nested
-                             (nested-info (make-check-info 'bar 2)
-                                          (make-check-info 'baz 3)))))
+    (define test-info (info* 'foo 1 'nested (nested-info* 'bar 2 'baz 3)))
     (define expected-str "foo:        1
 nested:
   bar:        2
@@ -30,12 +32,8 @@ nested:
     (check-info-stack-output expected-str test-info))
   (test-case "Double-nested check info printing"
     (define test-info
-      (list
-       (make-check-info
-        'nested (nested-info
-                 (make-check-info
-                  'double-nested (nested-info (make-check-info 'foo 1)
-                                              (make-check-info 'bar 2)))))))
+      (info* 'nested
+             (nested-info* 'double-nested (nested-info* 'foo 1 'bar 2))))
     (define expected-str "nested:
   double-nested:
     foo:            1


### PR DESCRIPTION
Closes #10, depends on #51 

This PR adds a `(nested-info info ...)` struct that allows custom checks to print an indented list of check infos under a single info key. The following check:

```racket
(define-check (foo)
  (define nested
    (nested-info (make-check-info 'bar 'bar)
                 (make-check-info 'baz 'baz)))
  (with-check-info (['foo nested])
    (fail-check)))
```

Raises a check failure with output like this:

```
--------------------
FAILURE
name:       foo
location:   unsaved-editor:10:0
params:     '()
foo:
  bar:        bar
  baz:        baz
--------------------
```