### PR TITLE
Add a parameter to disable test result logging

### DIFF
--- a/rackunit-doc/rackunit/scribblings/utils.scrbl
+++ b/rackunit-doc/rackunit/scribblings/utils.scrbl
@@ -52,7 +52,7 @@ and displaying a summary message.
  @racket[(current-error-port)]. If @racket[exit?] is true, then if there were
  failures, calls @racket[(exit 1)].}
 
-@defthing[test-log-enabled? (parameter/c boolean?)]{
+@defparam[test-log-enabled? enabled? boolean? #:value #t]{
  When set to @racket[#f], @racket[test-log!] is a no-op. This is useful to
  dynamically disable certain tests whose failures are expected and shouldn't be
  counted in the test log, such as when testing a custom check's failure

--- a/rackunit-doc/rackunit/scribblings/utils.scrbl
+++ b/rackunit-doc/rackunit/scribblings/utils.scrbl
@@ -38,22 +38,22 @@ as a predicate and passed each export of the module. If @racket[skip] is
 Rackunit provides a general purpose library for tracking test results
 and displaying a summary message.
 
-@defproc[(test-log! [result any/c])
-         void?]{
-
-Adds a test result to the running log. If @racket[result] is false,
-then the test is considered a failure.
-
-}
+@defproc[(test-log! [result any/c]) void?]{
+ Adds a test result to the running log. If @racket[result] is false,
+ then the test is considered a failure.}
 
 @defproc[(test-log [#:display? display? boolean? #t]
                    [#:exit? exit? boolean? #t])
          (cons/c exact-nonnegative-integer?
                  exact-nonnegative-integer?)]{
+ Processes the running test log. The first integer is the failed tests, the
+ second is the total tests. If @racket[display?] is true, then a message is
+ displayed. If there were failures, the message is printed on
+ @racket[(current-error-port)]. If @racket[exit?] is true, then if there were
+ failures, calls @racket[(exit 1)].}
 
-Processes the running test log. The first integer is the failed tests, the second is the total
-tests. If @racket[display?] is true, then a message is displayed. If there were failures, the
-message is printed on @racket[(current-error-port)]. If @racket[exit?] is true, then if there were
-failures, calls @racket[(exit 1)].
-
-}
+@defthing[test-log-enabled? (parameter/c boolean?)]{
+ When set to @racket[#f], @racket[test-log!] is a no-op. This is useful to
+ dynamically disable certain tests whose failures are expected and shouldn't be
+ counted in the test log, such as when testing a custom check's failure
+ behavior.}

--- a/rackunit-doc/rackunit/scribblings/utils.scrbl
+++ b/rackunit-doc/rackunit/scribblings/utils.scrbl
@@ -56,4 +56,5 @@ and displaying a summary message.
  When set to @racket[#f], @racket[test-log!] is a no-op. This is useful to
  dynamically disable certain tests whose failures are expected and shouldn't be
  counted in the test log, such as when testing a custom check's failure
- behavior.}
+ behavior.
+ @history[#:added "1.1"]}

--- a/rackunit-test/tests/rackunit/log.rkt
+++ b/rackunit-test/tests/rackunit/log.rkt
@@ -48,3 +48,10 @@
 (& (test-log #:display? #t) "" "1/2 test failures\n" 0)
 (& (test-log #:exit? #t) "" "" 1)
 (& (test-log #:display? #t #:exit? #t) "" "1/2 test failures\n" 1)
+
+(parameterize ([test-log-enabled? #f])
+  (check-true #t)
+  (& (test-log) "" "" 0)
+  (& (test-log #:display? #t) "" "1/2 test failures\n" 0)
+  (& (test-log #:exit? #t) "" "" 1)
+  (& (test-log #:display? #t #:exit? #t) "" "1/2 test failures\n" 1))

--- a/testing-util-lib/info.rkt
+++ b/testing-util-lib/info.rkt
@@ -5,6 +5,6 @@
 
 (define pkg-desc "Utilities for interoperating between testing frameworks")
 
-(define version "1.0")
+(define version "1.1")
 
 (define pkg-authors '(florence))

--- a/testing-util-lib/rackunit/log.rkt
+++ b/testing-util-lib/rackunit/log.rkt
@@ -1,6 +1,8 @@
 #lang racket/base
 (require racket/contract)
 
+(define test-log-enabled? (make-parameter #t))
+
 (define TOTAL 0)
 (define FAILED 0)
 
@@ -8,9 +10,10 @@
   (set! id (add1 id)))
 
 (define (test-log! result)
-  (inc! TOTAL)
-  (unless result
-    (inc! FAILED)))
+  (when (test-log-enabled?)
+    (inc! TOTAL)
+    (unless result
+      (inc! FAILED))))
 
 (define (test-log #:display? [display? #f]
                   #:exit? [exit? #f])
@@ -31,9 +34,8 @@
 
 (provide
  (contract-out
-  [test-log!
-   (-> any/c void?)]
-  [test-log
-   (->* () (#:display? boolean? #:exit? boolean?)
-        (cons/c exact-nonnegative-integer?
-                exact-nonnegative-integer?))]))
+  [test-log-enabled? (parameter/c boolean?)]
+  [test-log! (-> any/c void?)]
+  [test-log (->* () (#:display? boolean? #:exit? boolean?)
+                 (cons/c exact-nonnegative-integer?
+                         exact-nonnegative-integer?))]))


### PR DESCRIPTION
This is needed for #47; the meta checks need to ensure failing check expressions don't increment the test failure counter. This also helps with #9, as `define-check` can now parameterize `current-check-around` to disable test result logging inside wrapped checks.