### PR TITLE
Add replace-check-info and replace-check-info*

### DIFF
--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -369,7 +369,9 @@ misspelling errors:
    (define-check (fail/replaced-name)
      (replace-check-info [name "replaced!!!"]
        (fail-check)))
-   (fail/replaced-name))}
+   (fail/replaced-name))
+
+ @history[#:added "1.8"]}
 
 @defproc[(replace-check-info* [info check-info?] [thunk (-> any)]) any]{
  Like @racket[update-check-info], but as a normal procedure instead of a macro.
@@ -378,7 +380,9 @@ misspelling errors:
    #:eval rackunit-eval
    (define-check (fail/replaced-params)
      (replace-check-info* (make-params-info "replaced!!!") fail-check))
-   (fail/replaced-params))}
+   (fail/replaced-params))
+
+ @history[#:added "1.8"]}
 
 @section{Custom Checks}
 

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -353,7 +353,33 @@ misspelling errors:
              (make-check-info 'bar 2)))
      (with-check-info* custom-info fail-check))
    (fail/proc-info))}
-     
+
+@defform[(replace-check-info [name-id val-expr] body ...+)
+         #:contracts ([val-expr any/c])]{
+ Replaces the value of the current check info named @racket[name-id] with
+ @racket[val-expr] in the dynamic extent of the @racket[body] expressions. If no
+ check info named @racket[name-id] is present, appends a new check info to the
+ end of the stack. If multiple check infos named @racket[name-id] are present,
+ the first info has its value replaced and the other infos are removed. Unlike
+ @racket[with-check-info], @racket[name-id] is a plain identifier instead of an
+ expression producing a symbol.
+
+ @(examples
+   #:eval rackunit-eval
+   (define-check (fail/replaced-name)
+     (replace-check-info [name "replaced!!!"]
+       (fail-check)))
+   (fail/replaced-name))}
+
+@defproc[(replace-check-info* [info check-info?] [thunk (-> any)]) any]{
+ Like @racket[update-check-info], but as a normal procedure instead of a macro.
+
+ @(examples
+   #:eval rackunit-eval
+   (define-check (fail/replaced-params)
+     (replace-check-info* (make-params-info "replaced!!!") fail-check))
+   (fail/replaced-params))}
+
 @section{Custom Checks}
 
 Custom checks can be defined using @racket[define-check] and

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -1,5 +1,6 @@
 #lang scribble/doc
-@(require "base.rkt")
+@(require (except-in "base.rkt" examples)
+          scribble/example)
 
 @(require (for-label racket/match))
 
@@ -314,48 +315,45 @@ misspelling errors:
            [(make-check-actual (param any)) check-info?]
            [(make-check-expected (param any)) check-info?])]{}
 
+@defform[(with-check-info ([name-expr val-expr] ...) body ...+)
+         #:contracts ([name symbol?] [val-expr any/c])]{
+ Appends the given check infos to the check information stack for the dynamic
+ extent of the @racket[body] expressions. Note that to add a check info with
+ the name @racket[foo], an expression that produces the symbol @racket['foo]
+ must be provided rather than the literal @racket[foo] identifier. Multiple
+ infos with the same name can be added, in which case leftmost infos print
+ first.
+
+ @(examples
+   #:eval rackunit-eval
+   (define-check (fail/custom-info)
+     (with-check-info (['custom1 'foo] ['custom2 'bar])
+       (fail-check)))
+   (fail/custom-info))
+
+ A nested use of @racket[with-check-info] appends check info after the enclosing
+ use of @racket[with-check-info].
+
+ @(examples
+   #:eval rackunit-eval
+   (define-check (fail/nested-info)
+     (with-check-info (['outer 'foo])
+       (with-check-info (['inner 'bar])
+         (fail-check))))
+   (fail/nested-info))}
+
 @defproc[(with-check-info* (info (listof check-info?)) (thunk (-> any))) any]{
+ Like @racket[with-check-info], but as a normal procedure instead of a macro.
 
-Stores the given @racket[info] on the check-info stack for
-the duration (the dynamic extent) of the execution of
-@racket[thunk]}
-
-@interaction[#:eval rackunit-eval
-  (with-check-info*
-   (list (make-check-info 'time (current-seconds)))
-   (lambda () (check = 1 2)))
-]
-
-When this check fails the message
-
-@verbatim{time: <current-seconds-at-time-of-running-check>}
-
-is printed along with the usual information on an check failure.
-
-@defform[(with-check-info ((name val) ...) body ...)]{
-
-The @racket[with-check-info] macro stores the given
-information in the check information stack for the duration
-of the execution of the body expressions.  @racket[Name] is
-a quoted symbol and @racket[val] is any value.}
-
-@interaction[#:eval rackunit-eval
- (for-each
-  (lambda (elt)
-    (with-check-info
-     (('current-element elt))
-     (check-pred odd? elt)))
-  (list 1 3 5 7 8))
-]
-
-When this test fails the message
-
-@verbatim{current-element: 8}
-
-is displayed along with the usual information on an check failure.
-
-
-
+ @(examples
+   #:eval rackunit-eval
+   (define-check (fail/proc-info)
+     (define custom-info
+       (list (make-check-info 'foo 1)
+             (make-check-info 'bar 2)))
+     (with-check-info* custom-info fail-check))
+   (fail/proc-info))}
+     
 @section{Custom Checks}
 
 Custom checks can be defined using @racket[define-check] and

--- a/rackunit-lib/info.rkt
+++ b/rackunit-lib/info.rkt
@@ -11,4 +11,4 @@
 
 (define pkg-authors '(ryanc noel))
 
-(define version "1.7")
+(define version "1.8")

--- a/rackunit-lib/rackunit/private/test.rkt
+++ b/rackunit-lib/rackunit/private/test.rkt
@@ -24,6 +24,9 @@
          nested-info?
          nested-info-values
 
+         replace-check-info
+         replace-check-info*
+
          with-check-info
          with-check-info*
 

--- a/rackunit-test/tests/rackunit/check-info-test.rkt
+++ b/rackunit-test/tests/rackunit/check-info-test.rkt
@@ -48,6 +48,28 @@
           [expected (in-list (list 'a 'b 'c 'd 'e 'f))])
       (check-eq? (check-info-name actual) expected)))
 
+  (test-case "replace-check-info updates existing check info"
+    (define stack
+      (with-check-info (['a 1] ['b 2])
+        (replace-check-info [a 'new] (current-check-info))))
+    (check-equal? stack
+                  (list (make-check-info 'a 'new) (make-check-info 'b 2))))
+
+  (test-case "replace-check-info appends new check info"
+    (define stack
+      (with-check-info (['a 1] ['b 2])
+        (replace-check-info [new 'new] (current-check-info))))
+    (check-equal? stack
+                  (list (make-check-info 'a 1)
+                        (make-check-info 'b 2)
+                        (make-check-info 'new 'new))))
+
+  (test-case "replace-check-info removes extra check infos"
+    (define stack
+      (with-check-info (['a 1] ['a 2])
+        (replace-check-info [a 'new] (current-check-info))))
+    (check-equal? stack (list (make-check-info 'a 'new))))
+
   (test-case "check-actual? and check-expected? work"
     (check-true (check-actual? (make-check-actual 1)))
     (check-true (check-expected? (make-check-expected 1)))


### PR DESCRIPTION
Closes #58. Chose the name `replace-check-info` instead of `update-check-info` to make it clearer that existing infos are being changed in-place.

The `replace-check-info` macro takes the info name as a plain identifier rather than an expression the way `with-check-info`does. The expression behavior of `with-check-info` always seemed like a bizarre misfeature to me, and I constantly make the mistake of writing `(with-check-info ([foo 'foo]) ...)`. However, I'm on the fence about making `replace-check-info` inconsistent with `with-check-info`.