### PR TITLE
Fix with-check-info behavior for duplicate keys

### DIFF
--- a/rackunit-lib/rackunit/private/check-info.rkt
+++ b/rackunit-lib/rackunit/private/check-info.rkt
@@ -1,6 +1,8 @@
 #lang racket/base
+
 (require racket/contract/base
          racket/format
+         racket/list
          racket/port
          racket/pretty
          "location.rkt"
@@ -56,7 +58,10 @@
 
 ;; with-check-info* : (list-of check-info) thunk -> any
 (define (with-check-info* info thunk)
-  (parameterize ([current-check-info (append (current-check-info) info)])
+  (define all-infos (append (current-check-info) info))
+  (define infos/later-overriding-earlier
+    (reverse (remove-duplicates (reverse all-infos) #:key check-info-name)))
+  (parameterize ([current-check-info infos/later-overriding-earlier])
     (thunk)))
 
 (define-syntax with-check-info

--- a/rackunit-test/tests/rackunit/check-info-test.rkt
+++ b/rackunit-test/tests/rackunit/check-info-test.rkt
@@ -48,6 +48,18 @@
           [expected (in-list (list 'a 'b 'c 'd 'e 'f))])
       (check-eq? (check-info-name actual) expected)))
 
+  (test-case
+      "later with-check-info values override earlier values with same name"
+    (define stack (with-check-info (['a 1] ['a 2]) (current-check-info)))
+    (check-equal? stack (list (make-check-info 'a 2))))
+
+  (test-case "nested uses with-check-info override outer values with same name"
+    (define stack
+      (with-check-info (['a 1])
+        (with-check-info (['a 2])
+          (current-check-info))))
+    (check-equal? stack (list (make-check-info 'a 2))))
+
   (test-case "check-actual? and check-expected? work"
     (check-true (check-actual? (make-check-actual 1)))
     (check-true (check-expected? (make-check-expected 1)))


### PR DESCRIPTION
With this change, the check information stack acts more like an association list than a list or a hash. When using `with-check-info`, if an info is added with the same name as an existing info the new info replaces the old one, preserving the old info's location in the info stack.

Fixes #58, obsoletes #61 

Merge to release branch.