### PR TITLE
check-exn: stop ignore `message` argument

### DIFF
--- a/rackunit-lib/rackunit/private/check-info.rkt
+++ b/rackunit-lib/rackunit/private/check-info.rkt
@@ -20,11 +20,17 @@
   [struct verbose-info ([value any/c])]
   [info-value->string (-> any/c string?)]
   [current-check-info (parameter/c (listof check-info?))]
+  [check-info-contains-key? (check-info-> symbol? boolean?)]
+  [check-info-ref (check-info-> symbol? (or/c check-info? #f))]
   [with-check-info* ((listof check-info?) (-> any) . -> . any)])
  with-check-info)
 
 (module+ for-test
   (provide trim-current-directory))
+
+(define (check-info-> dom cod)
+  (case-> (-> dom cod)
+          (-> (listof check-info?) dom cod)))
 
 ;; Structures --------------------------------------------------
 
@@ -94,3 +100,17 @@
 (define-check-type message any/c)
 (define-check-type actual any/c #:wrapper pretty-info)
 (define-check-type expected any/c #:wrapper pretty-info)
+
+(define check-info-ref
+  (case-lambda
+   [(k)
+    (check-info-ref (current-check-info) k)]
+   [(info k)
+    (findf (λ (i) (eq? k (check-info-name i))) info)]))
+
+(define check-info-contains-key?
+  (case-lambda
+   [(k)
+    (check-info-contains-key? (current-check-info) k)]
+   [(info k)
+    (and (check-info-ref info k) #t)]))

--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -162,14 +162,17 @@
            [exn:fail?
             (lambda (exn)
               (with-check-info*
-               (list
-                (make-check-message "Wrong exception raised")
+               (list/if
+                (and (not (check-info-contains-key? 'message))
+                     (make-check-message "Wrong exception raised"))
                 (make-check-info 'exn-message (exn-message exn))
                 (make-check-info 'exn exn))
                (lambda () (fail-check))))])
         (thunk))
       (with-check-info*
-       (list (make-check-message "No exception raised"))
+       (list/if
+         (and (not (check-info-contains-key? 'message))
+              (make-check-message "No exception raised")))
        (lambda () (fail-check))))))
 
 (define-check (check-not-exn thunk)
@@ -179,8 +182,9 @@
        [exn?
         (lambda (exn)
           (with-check-info*
-           (list
-            (make-check-message "Exception raised")
+           (list/if
+            (and (not (check-info-contains-key? 'message))
+                 (make-check-message "Exception raised"))
             (make-check-info 'exception-message (exn-message exn))
             (make-check-info 'exception exn))
            (lambda () (fail-check))))])

--- a/rackunit-test/tests/rackunit/check-info-test.rkt
+++ b/rackunit-test/tests/rackunit/check-info-test.rkt
@@ -95,6 +95,22 @@
       (list 'name 'location 'expression 'params 'custom1 'custom2))
     (check-equal? (get-foo-info-names) expected-info-names))
 
+  (test-case "check-info-ref / check-info-contains-key"
+    (define info0 (list (make-check-name 'my-name)))
+    (define info1 (list (make-check-message 'my-message)))
+
+    (parameterize ([current-check-info info0])
+      (check-not-false (check-info-ref 'name))
+      (check-false (check-info-ref 'message))
+
+      (check-not-false (check-info-ref info1 'message))
+      (check-false (check-info-ref info1 'name))
+
+      (check-true (check-info-contains-key? 'name))
+      (check-false (check-info-contains-key? 'message))
+      (check-true (check-info-contains-key? info1 'message))
+      (check-false (check-info-contains-key? info1 'name))))
+
   (test-case "All tests for trim-current-directory"
     (test-case "trim-current-directory leaves directories outside the current directory alone"
       (check-equal? (trim-current-directory "/foo/bar/") "/foo/bar/"))


### PR DESCRIPTION
Fix `check-exn` to print the user's message if they supplied one, rather than the generic "No exception raised".

I think I need #59 to test this. Until then here's some checks I'd use to test:
```
#lang racket/base
(require rackunit)

(check-not-exn (λ () (/ 1 0)) "don't divide by 0")

(check-exn exn:fail? (λ () (void)) "this should raise an exception")

(check-exn exn:fail:user? (λ () (error 'death)) "should be user exn")
```

All these should print a `message:` with the user's message rather than the generic ones.
(Racket 6.7 does this, Racket 6.10 candidate doesn't)