### PR TITLE
doc: add deftech for check-info stack

### DIFF
--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -335,7 +335,7 @@ is printed along with the usual information on an check failure.
 @defform[(with-check-info ((name val) ...) body ...)]{
 
 The @racket[with-check-info] macro pushes the given
-information in the @tech{check-info stack} for the duration
+information onto the @tech{check-info stack} for the duration
 of the execution of the body expressions. Each @racket[name] must be
 a quoted symbol and each @racket[val] must be a value.}
 
@@ -414,8 +414,8 @@ We can use these checks in the usual way:
 
 The @racket[define-binary-check] macro constructs a check
 that tests a binary predicate.  Compared to
-@racket[define-simple-check], does a better job reporting check
-failures.  The first form of the macro accepts a binary
+@racket[define-simple-check], this macro does a better job reporting check
+failures.  The first form of @racket[define-binary-check] accepts a binary
 predicate and tests if the predicate holds for the given
 values.  The second form tests if the last @racket[body]
 evaluates to a non-false value.

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -259,24 +259,24 @@ included in the output.
 
 @section{Augmenting Information on Check Failure}
 
-When a check fails it stores information including the name
+When a check fails it stores @tech[#:key "check-info"]{information} including the name
 of the check, the location and message (if available), the
 expression the check is called with, and the parameters to
-the check.  Additional information can be stored by using
+the check.  Additional information can be @tech[#:key "check-info stack"]{stored} by using
 the @racket[with-check-info*] function, and the
 @racket[with-check-info] macro.
 
 @defstruct[check-info ([name symbol?] [value any]) #:transparent]{
- A check-info structure stores information associated with the context of the
+ A @deftech[#:key "check-info"]{check-info structure} stores information associated with the context of the
  execution of a check. The @racket[value] is written in a check failure message
  using @racket[write] unless it is a @racket[string-info] value or a
  @racket[nested-info] value.
  @history[#:changed "1.6" "Changed from opaque to transparent"]}
 
 @defstruct*[string-info ([value string?]) #:transparent]{
- A special wrapper around a string for use as a @racket[check-info] value. When
+ A special wrapper around a string for use as a @tech{check-info} value. When
  displayed in a check failure message, @racket[value] is displayed without
- quotes. Used to print messages in check infos instead of writing values.
+ quotes. Used to print messages instead of writing values.
  @(interaction
    #:eval rackunit-eval
    (define-check (string-info-check)
@@ -287,7 +287,7 @@ the @racket[with-check-info*] function, and the
  @history[#:added "1.2"]}
 
 @defstruct*[nested-info ([values (listof check-info?)]) #:transparent]{
- A special wrapper around a list of infos for use as a @racket[check-info]
+ A special wrapper around a list of @tech{check-infos} for use as a @racket[check-info]
  value. A check info whose value is a nested info is displayed as an indented
  subsequence of infos. Nested infos can be placed inside nested infos, yielding
  greater indentation.
@@ -300,8 +300,8 @@ the @racket[with-check-info*] function, and the
    (nested-info-check))
  @history[#:added "1.7"]}
 
-The are several predefined functions that create check
-information structures with predefined names.  This avoids
+The are several predefined functions that create @tech{check-info}
+structures with predefined names.  This avoids
 misspelling errors:
 
 @defproc*[([(make-check-name (name string?)) check-info?]
@@ -316,7 +316,7 @@ misspelling errors:
 
 @defproc[(with-check-info* (info (listof check-info?)) (thunk (-> any))) any]{
 
-Stores the given @racket[info] on the check-info stack for
+Pushes the given @racket[info] on the @tech{check-info stack} for
 the duration (the dynamic extent) of the execution of
 @racket[thunk]}
 
@@ -334,10 +334,10 @@ is printed along with the usual information on an check failure.
 
 @defform[(with-check-info ((name val) ...) body ...)]{
 
-The @racket[with-check-info] macro stores the given
-information in the check information stack for the duration
-of the execution of the body expressions.  @racket[Name] is
-a quoted symbol and @racket[val] is any value.}
+The @racket[with-check-info] macro pushes the given
+information in the @tech{check-info stack} for the duration
+of the execution of the body expressions. Each @racket[name] must be
+a quoted symbol and each @racket[val] must be a value.}
 
 @interaction[#:eval rackunit-eval
  (for-each
@@ -372,15 +372,17 @@ that code must be wrapped in a thunk (a function of no
 arguments) by the user.  The predefined @racket[check-exn]
 is an example of this type of check.
 
-It is also useful to understand how the check information stack
-operates.  The stack is stored in a parameter and the
-@racket[with-check-info] forms evaluate to calls to
-@racket[parameterize].  For this reason simple checks (see below)
+It is also useful to understand how the @deftech{check-info stack}
+operates.  The stack contains a list of @tech{check-info} structures;
+when a check fails, RackUnit interprets these structures to print an error
+message. The @tech{check-info stack} is stored in a parameter and the
+@racket[with-check-info] forms evaluate to
+@racket[parameterize] forms.  For this reason simple checks (see below)
 cannot usefully contain calls to @racket[with-check-info] to report
 additional information.  All checks created using
 @racket[define-simple-check] or @racket[define-check] grab some
-information by default: the name of the checks and the values of the
-parameters.  Additionally the macro forms of checks grab location
+information by default, for example the name of the checks and the values of the
+parameters.  Additionally, the macro forms of checks grab location
 information and the expressions passed as parameters.
 
 @defform[(define-simple-check (name param ...) body ...)]{
@@ -411,9 +413,9 @@ We can use these checks in the usual way:
           (define-binary-check (name actual expected) body ...)]]{
 
 The @racket[define-binary-check] macro constructs a check
-that tests a binary predicate.  It's benefit over
-@racket[define-simple-check] is in better reporting on check
-failure.  The first form of the macro accepts a binary
+that tests a binary predicate.  Compared to
+@racket[define-simple-check], does a better job reporting check
+failures.  The first form of the macro accepts a binary
 predicate and tests if the predicate holds for the given
 values.  The second form tests if the last @racket[body]
 evaluates to a non-false value.
@@ -432,9 +434,9 @@ In use:
   (check-char=? (read-char (open-input-string "a")) #\a)
 ]
 
-If the expression is more complicated the second form should
+If the expression is more complicated, the second form should
 be used.  For example, below we define a binary check that
-tests a number if within 0.01 of the expected value:
+tests whether a number is within 0.01 of the expected value:
 
 @interaction[#:eval rackunit-eval
   (define-binary-check (check-in-tolerance actual expected)
@@ -450,8 +452,8 @@ This allows more flexible checks, and in particular more flexible
 reporting options.}
 
 @defproc[(fail-check [message string?]) void?]{
-Raises an @racket[exn:test:check] with the contents of the check
-information stack. The optional message is used as the exception's
+Raises an @racket[exn:test:check] with the contents of the @tech{check-info stack}.
+The optional message is used as the exception's
 message.}
 
 @close-eval[rackunit-eval]


### PR DESCRIPTION
Define and use two deftechs:
- `check-info` (a key-value pair RackUnit uses to print error messages)
- `check-info stack` (a collection of `check-info`s that the user can extend)

I picked `check-info` rather than `check information` because that's how
 I'd rather talk about these things in real life.

I don't really like calling it a "stack", but I like saying "Pushes"
 in the doc for `with-check-info`.