### PR TITLE
Move test-log logic for checks and tests inside their "around" parameters

### DIFF
--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -81,7 +81,6 @@
 ;; given exception.  Useful for propogating internal
 ;; errors to the outside world.
 (define (refail-check exn)
-  (test-log! #f)
   (raise
    (make-exn:test:check (exn-message exn)
                         (exn-continuation-marks exn)

--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -51,14 +51,11 @@
 ;; plain-check-around.
 (define (check-around thunk)
   (define handler (current-check-handler))
-  (with-handlers ([(λ (_) #t) handler]) (thunk))
-  (void))
+  (with-handlers ([(λ (_) #t) handler]) (thunk)))
 
 ;; Evaluates a check just like a normal function, with no calls to test-log!
 ;; or the current check handler. Check failures are raised as plain exceptions.
-(define (plain-check-around chk-thunk)
-  (chk-thunk)
-  (void))
+(define (plain-check-around chk-thunk) (chk-thunk))
 
 ;; This is the default for current-check-around, and ensures a check logs
 ;; test results appropriately.

--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -14,12 +14,13 @@
 
 (provide
  (contract-out
-  [fail-check (->* () (string?) void?)]))
+  [fail-check (->* () (string?) void?)]
+  [current-check-handler (parameter/c (-> any/c any))]
+  [current-check-around (parameter/c (-> (-> void?) any))]
+  [plain-check-around (-> (-> void?) void?)]))
 
-(provide current-check-handler
-         check-around
-         current-check-around
-
+(provide check-around
+         
          define-check
          define-binary-check
          define-simple-check
@@ -41,32 +42,40 @@
          check-match
          fail)
 
-;; parameter current-check-handler : (-> any any)
-(define current-check-handler
-  (make-parameter
-   display-test-failure/error
-   (lambda (v)
-     (if (procedure? v)
-         v
-         (raise-type-error 'current-check-handler "procedure" v)))))
+(define current-check-handler (make-parameter display-test-failure/error))
 
-;; check-around : ( -> a) -> a
+;; Like default-check-around, except without test logging. This used to be used
+;; by test-case, and is currently undocumented. Typed Racket's wrapper around
+;; rackunit uses this (although it shouldn't) so we can't get rid of it yet.
+;; Setting (current-check-handler) to `raise` makes this equivalent to
+;; plain-check-around.
 (define (check-around thunk)
-  (with-handlers ([(lambda (e) #t) (current-check-handler)])
-    (thunk)))
+  (define handler (current-check-handler))
+  (with-handlers ([(λ (_) #t) handler]) (thunk))
+  (void))
 
-;; parameter current-check-around : (( -> a) -> a)
-(define current-check-around
-  (make-parameter
-   (λ (thunk) (check-around thunk) (void))
-   (lambda (v)
-     (if (procedure? v)
-         v
-         (raise-type-error 'current-check-around "procedure" v)))))
+;; Evaluates a check just like a normal function, with no calls to test-log!
+;; or the current check handler. Check failures are raised as plain exceptions.
+(define (plain-check-around chk-thunk)
+  (chk-thunk)
+  (void))
+
+;; This is the default for current-check-around, and ensures a check logs
+;; test results appropriately.
+(define (default-check-around chk-thunk)
+  (define handler (current-check-handler))
+  (define (log-and-handle! e) (test-log! #f) (handler e))
+  ;; Nested checks should be evaluated as normal functions, to avoid double
+  ;; counting test results.
+  (parameterize ([current-check-around plain-check-around])
+    (with-handlers ([(λ (_) #t) log-and-handle!])
+      (chk-thunk)
+      (test-log! #t))))
+
+(define current-check-around (make-parameter default-check-around))
 
 (define (fail-check [message ""])
   (define marks (current-continuation-marks))
-  (test-log! #f)
   (raise (make-exn:test:check message marks (current-check-info))))
 
 ;; refail-check : exn:test:check -> (exception raised)
@@ -88,17 +97,14 @@
   (define (name formal ... [message #f]
                 #:location [location (list 'unknown #f #f #f #f)]
                 #:expression [expression 'unknown])
-    (with-check-info*
-        (list/if (make-check-name 'pub)
-                 (make-check-location location)
-                 (make-check-expression expression)
-                 (make-check-params (list formal ...))
-                 (and message (make-check-message message)))
-      (λ ()
-        ((current-check-around)
-         (λ () (begin0 (let () body ...) (test-log! #t))))))
-    ;; All checks should return (void)
-    (void)))
+    (define infos
+      (list/if (make-check-name 'pub)
+               (make-check-location location)
+               (make-check-expression expression)
+               (make-check-params (list formal ...))
+               (and message (make-check-message message))))
+    (with-check-info* infos
+      (λ () ((current-check-around) (λ () body ... (void)))))))
 
 (define-simple-macro (define-check (name:id formal:id ...) body:expr ...)
   (begin

--- a/rackunit-lib/rackunit/private/test-case.rkt
+++ b/rackunit-lib/rackunit/private/test-case.rkt
@@ -54,13 +54,15 @@
 
 (define-syntax (test-begin stx)
   (syntax-case stx ()
-    [(_ expr ...)
+    [(_ body ...)
      (syntax/loc stx
        ((current-test-case-around)
         (lambda ()
           (parameterize ([current-check-around plain-check-around])
+            ;; empty parameterize body is a syntax error, but an empty
+            ;; test-begin body is allowed
             (void)
-            expr ...))))]
+            body ...))))]
     [_
      (raise-syntax-error
       #f

--- a/rackunit-lib/rackunit/private/test-case.rkt
+++ b/rackunit-lib/rackunit/private/test-case.rkt
@@ -28,9 +28,11 @@
 ;;
 ;; Run a test-case immediately, printing information on failure
 (define (default-test-case-around thunk)
-  (with-handlers ([(lambda (e) (not (exn:break? e))) default-test-case-handler])
-    (parameterize ((current-custodian (make-custodian)))
-      (thunk))))
+  (begin0
+    (with-handlers ([(λ (_) #t) log-and-handle!])
+      (parameterize ((current-custodian (make-custodian)))
+        (thunk)))
+    (test-log! #t)))
 
 ;; default-test-case-handler : any -> any
 (define (default-test-case-handler e)
@@ -44,23 +46,21 @@
          v
          (raise-type-error 'current-test-case-around "procedure" v)))))
 
+(define (log-and-handle! e)
+  (test-log! #f)
+  (if (exn:break? e)
+      (raise e)
+      (default-test-case-handler e)))
+
 (define-syntax (test-begin stx)
   (syntax-case stx ()
     [(_ expr ...)
      (syntax/loc stx
        ((current-test-case-around)
         (lambda ()
-          (with-handlers ([(λ (e)
-                             (and (exn:fail? e)
-                                  (not (exn:test? e))))
-                           (λ (e)
-                             (test-log! #f)
-                             (raise e))])
-          (parameterize
-              ([current-check-handler raise]
-               [current-check-around  check-around])
+          (parameterize ([current-check-around plain-check-around])
             (void)
-            expr ...)))))]
+            expr ...))))]
     [_
      (raise-syntax-error
       #f

--- a/rackunit-lib/rackunit/private/test-suite.rkt
+++ b/rackunit-lib/rackunit/private/test-suite.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require (for-syntax racket/base)
+         rackunit/log
          "base.rkt"
          "test-case.rkt"
          "check.rkt")
@@ -39,15 +40,15 @@
       (current-seed (fhere test name thunk seed)))))
 
 
-(define delayed-test-case-around
-  (lambda (thunk)
-    (let ([name (current-test-name)])
-      (make-rackunit-test-case name thunk))))
+(define (delayed-test-case-around thunk)
+  (define name (current-test-name))
+  (define (thunk/nolog)
+    (parameterize ([test-log-enabled? #f])
+      (thunk)))
+  (make-rackunit-test-case name thunk/nolog))
 
-(define delayed-check-around
-  (lambda (thunk)
-    (let ([name #f])
-      (make-rackunit-test-case name thunk))))
+(define (delayed-check-around thunk)
+  (make-rackunit-test-case #f thunk))
 
 (define-syntax delay-test
   (syntax-rules ()

--- a/rackunit-test/tests/rackunit/all-rackunit-tests.rkt
+++ b/rackunit-test/tests/rackunit/all-rackunit-tests.rkt
@@ -18,13 +18,11 @@
 (define all-rackunit-tests
   (test-suite
    "All RackUnit Tests"
-   check-tests
    base-tests
    test-case-tests
    test-suite-tests
    test-suite-define-provide-test
    location-tests
-   result-tests
    test-tests
    util-tests
    text-ui-tests

--- a/rackunit-test/tests/rackunit/check-test.rkt
+++ b/rackunit-test/tests/rackunit/check-test.rkt
@@ -35,14 +35,12 @@
          rackunit/private/result
          rackunit/private/test-suite)
 
-(provide check-tests)
-
 (define (make-failure-test name pred . args)
   (test-case
-   name
-   (check-exn exn:test:check?
-              (lambda ()
-                (apply pred args)))))
+      name
+    (check-exn exn:test:check?
+               (lambda ()
+                 (apply pred args)))))
 
 ;; NOTE(jpolitz): Not generalizing make-failure-test above because (at
 ;; least) util-test expects it to be present, not exported, and a
@@ -51,10 +49,10 @@
   (syntax-rules ()
     [(_ name pred arg ...)
      (test-case
-      name
-      (check-exn exn:test:check?
-                 (lambda ()
-                   (pred arg ...))))]))
+         name
+       (check-exn exn:test:check?
+                  (lambda ()
+                    (pred arg ...))))]))
 
 (define-check (good)
   #t)
@@ -62,146 +60,144 @@
 (define-check (bad)
   (fail-check))
 
-(define check-tests
-  (test-suite
-   "Check tests"
-   ;; Successes
-   (test-case "Simple check-equal? test"
-              (check-equal? 1 1))
-   (test-case "Simple check-eq? test"
-              (check-eq? 'a 'a))
-   (test-case "Simple check-eqv? test"
-              (check-eqv? 'a 'a))
-   (test-case "Simple check test"
-              (check string=? "hello" "hello"))
-   (test-case "Simple check-true test"
-              (check-true (eq? 'a 'a)))
-   (test-case "Simple check-pred test"
-              (check-pred null? (list)))
-   (test-case "Simple check-exn test"
-              (check-exn exn:test:check?
-                         (lambda ()
-                           (check = 1 2))))
-   (test-case "Simple check-not-exn test"
-              (check-not-exn
+(test-case "Check tests"
+  ;; Successes
+  (test-case "Simple check-equal? test"
+    (check-equal? 1 1))
+  (test-case "Simple check-eq? test"
+    (check-eq? 'a 'a))
+  (test-case "Simple check-eqv? test"
+    (check-eqv? 'a 'a))
+  (test-case "Simple check test"
+    (check string=? "hello" "hello"))
+  (test-case "Simple check-true test"
+    (check-true (eq? 'a 'a)))
+  (test-case "Simple check-pred test"
+    (check-pred null? (list)))
+  (test-case "Simple check-exn test"
+    (check-exn exn:test:check?
                (lambda ()
-                 (check = 1 1))))
-   (test-case "Simple check-not-eq?"
-              (check-not-eq? (cons 'a 'a) (cons 'a 'a)))
-   (test-case "Simple check-not-equal?"
-              (check-not-equal? 1 2))
-   (test-case "Defined check succeeds"
-              (good))
-   (test-case "Simple check-not-false test"
-              (check-not-false 3))
-   (test-case "Simple check-= test"
-              (check-= 1.0 1.0 0.0001))
+                 (check = 1 2))))
+  (test-case "Simple check-not-exn test"
+    (check-not-exn
+     (lambda ()
+       (check = 1 1))))
+  (test-case "Simple check-not-eq?"
+    (check-not-eq? (cons 'a 'a) (cons 'a 'a)))
+  (test-case "Simple check-not-equal?"
+    (check-not-equal? 1 2))
+  (test-case "Defined check succeeds"
+    (good))
+  (test-case "Simple check-not-false test"
+    (check-not-false 3))
+  (test-case "Simple check-= test"
+    (check-= 1.0 1.0 0.0001))
    
-   (test-case "Use of check as expression"
-              (for-each check-false '(#f #f #f)))
-   (test-case "Use of local check as expression"
-              (let ()
-                (define-simple-check (check-symbol? x)
-                  (symbol? x))
-                (for-each check-symbol? '(a b c))))
+  (test-case "Use of check as expression"
+    (for-each check-false '(#f #f #f)))
+  (test-case "Use of local check as expression"
+    (let ()
+      (define-simple-check (check-symbol? x)
+        (symbol? x))
+      (for-each check-symbol? '(a b c))))
 
-   (test-case "Trivial check-match test"
-              (check-match "dirigible" _))
+  (test-case "Trivial check-match test"
+    (check-match "dirigible" _))
 
-   (test-case "Simple check-match test"
-              (check-match (list 1 2 3) (list _ _ 3)))
+  (test-case "Simple check-match test"
+    (check-match (list 1 2 3) (list _ _ 3)))
 
-   (test-case "check-match with a nested struct"
-              (let ()
-                (struct data (f1 f2 f3))
-                (check-match (data 1 2 (data 1 2 3))
-                             (data _ 2 (data _ _ _)))))
+  (test-case "check-match with a nested struct"
+    (let ()
+      (struct data (f1 f2 f3))
+      (check-match (data 1 2 (data 1 2 3))
+                   (data _ 2 (data _ _ _)))))
 
-   (test-case "Simple check-match test with a binding pred"
-              (check-match 3 x (odd? x)))
+  (test-case "Simple check-match test with a binding pred"
+    (check-match 3 x (odd? x)))
 
-   (test-case "check-match with a nested struct and a binding pred"
-              (let ()
-                (struct data (f1 f2 f3))
-                (check-match (data 1 2 (data 1 2 3))
-                             (data _ _ (data x y z))
-                             (equal? (+ x y z) 6))))
+  (test-case "check-match with a nested struct and a binding pred"
+    (let ()
+      (struct data (f1 f2 f3))
+      (check-match (data 1 2 (data 1 2 3))
+                   (data _ _ (data x y z))
+                   (equal? (+ x y z) 6))))
    
-   ;; Failures
-   (make-failure-test "check-equal? failure"
-                      check-equal? 1 2)
-   (make-failure-test "check-eq? failure"
-                      check-eq? 'a 'b)
-   (make-failure-test "check-eqv? failure"
-                      check-eqv? 'a 'b)
-   (make-failure-test "check failure"
-                      check string=? "hello" "bye")
-   (make-failure-test "check-true failure"
-                      check-true (eq? 'a 'b))
-   (make-failure-test "check-pred failure"
-                      check-pred null? (list 1 2 3))
-   (make-failure-test "check-exn failure"
-                      check-exn exn:test:check? (lambda () (check = 1 1)))
-   (make-failure-test "check-exn wrong exception"
-                      check-exn exn:fail:contract:arity? (lambda () (+ 1 2)))
-   (make-failure-test "check-not-exn"
-                      check-not-exn (lambda () (/ 1 0)))
-   (make-failure-test "fail with message failure"
-                      fail "With message")
-   (make-failure-test "fail without message failure"
-                      fail)
-   (make-failure-test "Defined check fails"
-                      bad)
-   (make-failure-test "check-not-false failure"
-                      check-not-false #f)
-   (make-failure-test "check-= failure"
-                      check-= 1.0 2.0 0.0)
+  ;; Failures
+  (make-failure-test "check-equal? failure"
+                     check-equal? 1 2)
+  (make-failure-test "check-eq? failure"
+                     check-eq? 'a 'b)
+  (make-failure-test "check-eqv? failure"
+                     check-eqv? 'a 'b)
+  (make-failure-test "check failure"
+                     check string=? "hello" "bye")
+  (make-failure-test "check-true failure"
+                     check-true (eq? 'a 'b))
+  (make-failure-test "check-pred failure"
+                     check-pred null? (list 1 2 3))
+  (make-failure-test "check-exn failure"
+                     check-exn exn:test:check? (lambda () (check = 1 1)))
+  (make-failure-test "check-exn wrong exception"
+                     check-exn exn:fail:contract:arity? (lambda () (+ 1 2)))
+  (make-failure-test "check-not-exn"
+                     check-not-exn (lambda () (/ 1 0)))
+  (make-failure-test "fail with message failure"
+                     fail "With message")
+  (make-failure-test "fail without message failure"
+                     fail)
+  (make-failure-test "Defined check fails"
+                     bad)
+  (make-failure-test "check-not-false failure"
+                     check-not-false #f)
+  (make-failure-test "check-= failure"
+                     check-= 1.0 2.0 0.0)
 
-   (make-failure-test/stx "check-match failure pred"
-                          check-match 5 x (even? x))
+  (make-failure-test/stx "check-match failure pred"
+                         check-match 5 x (even? x))
 
-   (make-failure-test/stx "check-match failure match"
-                           check-match (list 4 5) (list _))
+  (make-failure-test/stx "check-match failure match"
+                         check-match (list 4 5) (list _))
    
-   (test-case "check-= allows differences within epsilon"
-              (check-= 1.0 1.09 1.1))
+  (test-case "check-= allows differences within epsilon"
+    (check-= 1.0 1.09 1.1))
    
-   (make-failure-test "check-= failure > epsilon"
-                      check-= 1 12/10 1/10)
+  (make-failure-test "check-= failure > epsilon"
+                     check-= 1 12/10 1/10)
    
-   (test-case "check-as-expression failure"
-              (check-exn exn:test:check?
-                         (lambda ()
-                           (for-each check-false '(#f not-false)))))
+  (test-case "check-as-expression failure"
+    (check-exn exn:test:check?
+               (lambda ()
+                 (for-each check-false '(#f not-false)))))
    
-   (test-case
-    "Check allows optional message"
+  (test-case
+      "Check allows optional message"
     (begin
       (check = 1 1 "message")))
    
-   ;; Some necessary semantics
-   (test-case
-    "Check macro parameters evaluated once (simple-check)"
+  ;; Some necessary semantics
+  (test-case
+      "Check macro parameters evaluated once (simple-check)"
     (let ((counter 0))
       (check-true (begin (set! counter (add1 counter))
                          #t))
       (check = counter 1)))
-   (test-case
-    "Check macro parameters evaluated once (binary-check)"
+  (test-case
+      "Check macro parameters evaluated once (binary-check)"
     (let ((counter 0))
       (check-equal? (begin (set! counter (add1 counter))
                            1)
                     (begin (set! counter (add1 counter))
                            1))
       (check = counter 2)))
-   (test-case
-    "Check function parameters evaluated once (simple-check)"
+  (test-case
+      "Check function parameters evaluated once (simple-check)"
     (let ((counter 0))
       (check-true (begin (set! counter (add1 counter))
                          #t))
       (check = counter 1)))
-   (test-case
-    "Check function parameters evaluated once (binary-check)"
+  (test-case
+      "Check function parameters evaluated once (binary-check)"
     (let ((counter 0))
       (check-equal? (begin (set! counter (add1 counter))
                            1)
@@ -209,23 +205,23 @@
                            1))
       (check = counter 2)))
    
-   ;; Exceptions have the correct types
-   (test-case
-    "Macro w/ no message, message is a string"
+  ;; Exceptions have the correct types
+  (test-case
+      "Macro w/ no message, message is a string"
     (let ((exn (with-handlers ([exn? (lambda (exn)
                                        exn)])
                  (check-true #f))))
       (check-pred string? (exn-message exn))))
-   (test-case
-    "Function w/ no message, message is a string"
+  (test-case
+      "Function w/ no message, message is a string"
     (let ((exn (with-handlers ([exn? (lambda (exn)
                                        exn)])
                  (check-true #f))))
       (check-pred string? (exn-message exn))))
    
-   ;; The check construction language
-   (test-case
-    "with-check-info* captures information"
+  ;; The check construction language
+  (test-case
+      "with-check-info* captures information"
     (let ((name (make-check-info 'name "name"))
           (info (make-check-info 'info "info")))
       (with-handlers
@@ -238,11 +234,11 @@
                   (check-equal? name actual-name)
                   (check-equal? info actual-info)))))]
         (with-check-info*
-         (list name info)
-         (lambda ()
-           (fail-check))))))
-   (test-case
-    "with-check-info captures information"
+            (list name info)
+          (lambda ()
+            (fail-check))))))
+  (test-case
+      "with-check-info captures information"
     (with-handlers
         [(exn:test:check?
           (lambda (exn)
@@ -255,10 +251,10 @@
                 (check-eq? (check-info-name info) 'info)
                 (check string=? (check-info-value info) "info")))))]
       (with-check-info
-       (('name "name") ('info "info"))
-       (fail-check))))
-   (test-case
-    "check information stack unwinds"
+          (('name "name") ('info "info"))
+        (fail-check))))
+  (test-case
+      "check information stack unwinds"
     (with-handlers
         [(exn:test:check?
           (lambda (exn)
@@ -271,23 +267,23 @@
                 (check-eq? (check-info-name info) 'info)
                 (check string=? (check-info-value info) "info")))))]
       (with-check-info
-       (('name "name") ('info "info"))
-       (with-check-info
-        (('name "name") ('info "info"))
-        #t)
-       (fail-check))))
+          (('name "name") ('info "info"))
+        (with-check-info
+            (('name "name") ('info "info"))
+          #t)
+        (fail-check))))
    
-   ;; If check-exn isn't working correctly many tests above will
-   ;; silently fail.  Here we test check-exn is working.
-   (test-case
-    "check-exn traps exception"
+  ;; If check-exn isn't working correctly many tests above will
+  ;; silently fail.  Here we test check-exn is working.
+  (test-case
+      "check-exn traps exception"
     (with-handlers
         ((exn?
           (lambda (exn) (fail "Received exception"))))
       (check-exn exn:fail:contract:arity?
                  (lambda () (= 1)))))
-   (test-case
-    "check-exn fails if no exception raised"
+  (test-case
+      "check-exn fails if no exception raised"
     (with-handlers
         ((exn:test:check?
           (lambda (exn) #t))
@@ -296,12 +292,12 @@
       (check-exn exn? (lambda () (= 1 1)))
       (= 1)))
    
-   (test-case
-    "check-not-exn captures exception information if one raised"
+  (test-case
+      "check-not-exn captures exception information if one raised"
     (let* ([case (delay-test
                   (test-case "check-not-exn"
-                             (check-not-exn
-                              (lambda () (error "Oh dear!")))))]
+                    (check-not-exn
+                     (lambda () (error "Oh dear!")))))]
            [result (test-failure-result (car (run-test case)))]
            [names (map check-info-name
                        (exn:test:check-stack result))])
@@ -318,64 +314,64 @@
                    found?))
              #f names))))
 
-   (test-case
-    "check-exn has check failure message"
+  (test-case
+      "check-exn has check failure message"
     (let* ([case (delay-test
                   (test-case "check-exn"
-                             (check-exn #rx"ZZZZZ"
-                              (lambda () (fail-check "The Message")))))]
+                    (check-exn #rx"ZZZZZ"
+                               (lambda () (fail-check "The Message")))))]
            [result (test-failure-result (car (run-test case)))]
            [names (map check-info-name
                        (exn:test:check-stack result))])
       (check-equal?
-        "The Message"
-        (exn-message result))))
+       "The Message"
+       (exn-message result))))
 
-   (test-case
-    "check-not-exn has check failure message"
+  (test-case
+      "check-not-exn has check failure message"
     (let* ([case (delay-test
                   (test-case "check-not-exn"
-                             (check-not-exn
-                              (lambda () (fail-check "The Message")))))]
+                    (check-not-exn
+                     (lambda () (fail-check "The Message")))))]
            [result (test-failure-result (car (run-test case)))]
            [names (map check-info-name
                        (exn:test:check-stack result))])
       (check-equal?
-        "The Message"
-        (exn-message result))))
+       "The Message"
+       (exn-message result))))
    
-   ;; Verify that check-exn and check-not-exn raise errors (not check
-   ;; failures) if not given thunks.
-   (test-case
-    "check-exn raises contract exception if not given a procedure"
+  ;; Verify that check-exn and check-not-exn raise errors (not check
+  ;; failures) if not given thunks.
+  (test-case
+      "check-exn raises contract exception if not given a procedure"
     (check-exn exn:fail:contract?
                (lambda ()
                  (check-exn exn:fail? 'not-a-procedure))))
 
-   (test-case
-    "check-exn raises contract exception if given a procedure with incorrect arity"
+  (test-case
+      "check-exn raises contract exception if given a procedure with incorrect arity"
     (check-exn exn:fail:contract?
                (lambda ()
                  (check-exn exn:fail? (lambda (x) x)))))
 
-   (test-case
-    "check-not-exn raises contract exception if not given a procedure"
+  (test-case
+      "check-not-exn raises contract exception if not given a procedure"
     (check-exn exn:fail:contract?
                (lambda ()
                  (check-not-exn 'not-a-procedure))))
 
-   (test-case
-    "check-not-exn raises contract exception if given a procedure with incorrect arity"
+  (test-case
+      "check-not-exn raises contract exception if given a procedure with incorrect arity"
     (check-exn exn:fail:contract?
                (lambda ()
                  (check-not-exn (lambda (x) x)))))
 
-   ;; Regression test
-   ;; Uses of check (and derived forms) used to be un-compilable!
-   ;; We check that (write (compile --code-using-check--)) works.
-   ;; That involves some namespace hacking.
-   (test-case
-    "Checks are compilable"
+  ;; Regression test
+  ;; Uses of check (and derived forms) used to be un-compilable!
+  ;; We check that (write (compile --code-using-check--)) works.
+  ;; That involves some namespace hacking.
+  (test-case
+      "Checks are compilable"
     (let ((destns (make-base-namespace))
           (cns (current-namespace)))
       (parameterize ((current-namespace destns))
@@ -399,19 +395,19 @@
                            (open-input-string stx-string)))
                  (open-output-string))))))
    
-   ;; Check evaluation contexts
-   (test-case
-    "current-check-around is used by checks"
+  ;; Check evaluation contexts
+  (test-case
+      "current-check-around is used by checks"
     (let ([x #f])
       (parameterize ([current-check-around (lambda (t) (set! x 'foo))])
-                 (check-eq? 'a 'b))
+        (check-eq? 'a 'b))
       (check-eq? x
                  'foo)))
 
-   (test-case
-    "current-check-handler is used by checks"
+  (test-case
+      "current-check-handler is used by checks"
     (check-eq? (let/ec escape
-                 (parameterize ([current-check-handler (lambda (e) (escape 'foo))])
+                 (parameterize ([current-check-handler (lambda (e) (escape 'foo))]
+                                [current-check-around check-around])
                    (check-eq? 'a 'b)))
-               'foo))
-   ))
+               'foo)))

--- a/rackunit-test/tests/rackunit/log.rkt
+++ b/rackunit-test/tests/rackunit/log.rkt
@@ -14,7 +14,8 @@
     (define stdout-ev stdout-e)
     (define stdout-av stdout-p)
     (unless (equal? stdout-ev stdout-av)
-      (error 'log "Bad ~a: ~v vs ~v" label stdout-ev stdout-av))))
+      (error 'log "bad ~a\n actual: ~v\n expected: ~v"
+             label stdout-av stdout-ev))))
 
 (define-syntax-rule (& test-e stdout-e stderr-e exit-e)
   (let ()

--- a/rackunit-test/tests/rackunit/result-test.rkt
+++ b/rackunit-test/tests/rackunit/result-test.rkt
@@ -3,42 +3,37 @@
 (require rackunit
          rackunit/private/result)
 
-(provide result-tests)
-  
-(define result-tests
-  (test-suite
-   "All tests for result"
+(test-case "All tests for result"
 
-   (test-equal?
-    "fold-test-results returns seed"
-    (fold-test-results
-     (lambda (result seed) seed)
-     'hello
-     (delay-test (test-case "Demo" (check = 1 1)))
-     #:fdown (lambda (name seed) seed)
-     #:run run-test-case)
-    'hello)
+  (test-equal?
+   "fold-test-results returns seed"
+   (fold-test-results
+    (lambda (result seed) seed)
+    'hello
+    (delay-test (test-case "Demo" (check = 1 1)))
+    #:fdown (lambda (name seed) seed)
+    #:run run-test-case)
+   'hello)
 
-   (test-equal?
-    "fold-test-results return values of run to result-fn"
-    (fold-test-results
-     (lambda (v1 v2 seed)
-       (check-equal? v1 'v1)
-       (check-equal? v2 'v2)
-       seed)
-     'hello
-     (delay-test (test-case "Demo" (check = 1 1)))
-     #:run (lambda (name action) (values 'v1 'v2)))
-    'hello)
+  (test-equal?
+   "fold-test-results return values of run to result-fn"
+   (fold-test-results
+    (lambda (v1 v2 seed)
+      (check-equal? v1 'v1)
+      (check-equal? v2 'v2)
+      seed)
+    'hello
+    (delay-test (test-case "Demo" (check = 1 1)))
+    #:run (lambda (name action) (values 'v1 'v2)))
+   'hello)
 
-   (test-equal?
-    "fold-test-results calls run with name and action"
-    (fold-test-results
-     (lambda (result seed) seed)
-     'hello
-     (delay-test (test-case "Demo" 'boo))
-     #:run (lambda (name action)
-             (check string=? name "Demo")
-             (check-equal? (action) 'boo)))
-    'hello)
-   ))
+  (test-equal?
+   "fold-test-results calls run with name and action"
+   (fold-test-results
+    (lambda (result seed) seed)
+    'hello
+    (delay-test (test-case "Demo" 'boo))
+    #:run (lambda (name action)
+            (check string=? name "Demo")
+            (check-equal? (action) 'boo)))
+   'hello))


### PR DESCRIPTION
Closes #70 
Closes #9 
Closes #14 
Closes #58 

This PR moves the `test-log!` logic of checks and test cases into the `current-check-around` and `current-test-case-around` parameters, respectively. Additionally, checks now parameterize `current-check-around` inside the body of `define-check` so that *nested* checks are evaluated as normal functions. This allows checks to be *imperatively composed*; they can be chained together in series just like normal exception-throwing validation functions. This involves several subtle changes to the effects and evaluation of checks:

### Single nested check

```racket
(define-check (check-zero v)
  (check-equal? v 0))

(check-zero 0)
```

This now reports one test passing, and uses the default check info added by `check-zero`. Previously, it would report two tests passing.

### Multiple nested checks

```racket
(define-check (check-zero-twice v)
  (check-equal? v 0)
  (check-equal? v 0))

(check-zero-twice 0)
(check-zero-twice 1)
```

The passing use reports one test passing, and the failing use reports one test failing with the check failure thrown by the first `check-equal?` expression. Previously, the passing use reported two tests passing and the failing use reported two tests failing and one test passing, as each of the nested checks would raise and swallow a check failure leading the outer check to believe nothing went wrong.

### Multiple nested checks in test case

```racket
(test-case "passing test"
  (check-zero-twice 0))
(test-case "failing test"
  (check-zero-twice 1))
```

The passing test now reports one test passing, and the failing test reports one test failing. The passing test previously reported three tests passing, and the failing test previously reported one test passing *and* one test failing. It also only evaluated the first check inside `check-zero-twice`.

### Multiple checks in a test case

```racket
(test-case "passing test"
  (check-equal? 1 1)
  (check-equal? 2 2))
(test-case "failing test"
  (check-equal? 1 1)
  (check-equal? 2 3))
```

The passing test now reports one test passing, and the failing test now reports one test failing. Previously the passing test reported two tests passing and the failing test reported one test passing and two tests failing.

### Check in a test suite

For all test suites, calling `run-tests` on a suite now causes `test-log!` to report the same number of passing and failing tests as `run-tests` displays in its summary message. Previously, `test-log!` would report significantly more tests than `run-tests` claimed.

### Other changes

- Some parameters now use contracts instead of manually checking types
- Some of rackunit's own tests are now plain `test-case` expressions instead of `test-suite` definitions provided and combined in `all-rackunit-tests.rkt`
- The `rackunit/log` tests now have slightly better failure messages
- Calls to `test-log!` now need to be explicitly made by the user of `fold-test-results` or `foldts-test-results`. This also allows rackunit test suites to be run without interacting with `rackunit/log` at all (which the GUI runner probably wants to do anyway)

### Future work

This doesn't add any documentation of how rackunit checks behave when composed. It now mostly works "as expected", but without docs and tests guaranteeing this behavior it's not safe for users to rely on.

There are corresponding changes that need to be made in Typed Racket's [rackunit wrapper code](https://github.com/racket/typed-racket/tree/master/typed-racket-more/typed/rackunit) that duplicates rackunit's test case and test suite macros.