### PR TITLE
Add dynamic-info

### DIFF
--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -315,7 +315,7 @@ the @racket[with-check-info*] function, and the
    #:eval rackunit-eval
    (with-check-info (['current-dir (dynamic-info current-directory)])
      (check-equal? 1 2)
-     (parameterize ([current-directory "/tmp"])
+     (parameterize ([current-directory (find-system-path 'temp-dir)])
        (check-equal? 1 2))))
 
  @history[#:added "1.9"]}

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -318,6 +318,20 @@ the @racket[with-check-info*] function, and the
      (parameterize ([current-directory (find-system-path 'temp-dir)])
        (check-equal? 1 2))))
 
+ The value returned by @racket[proc] may itself be a special formatting value
+ such as @racket[nested-info] (or even another @racket[dynamic-info]), in which
+ case that value is rendered as it would be if it had not been wrapped in
+ @racket[dynamic-info].
+
+ @(interaction
+   #:eval rackunit-eval
+   (define current-foo (make-parameter #f))
+   (with-check-info (['foo (dynamic-info current-foo)])
+     (check-equal? 1 2)
+     (parameterize ([current-foo
+                     (nested-info (list (make-check-info 'nested 'foo)))])
+       (check-equal? 1 2))))
+
  @history[#:added "1.9"]}
 
 The are several predefined functions that create @tech{check-info}

--- a/rackunit-lib/info.rkt
+++ b/rackunit-lib/info.rkt
@@ -11,4 +11,4 @@
 
 (define pkg-authors '(ryanc noel))
 
-(define version "1.7")
+(define version "1.8")

--- a/rackunit-lib/rackunit/private/check-info.rkt
+++ b/rackunit-lib/rackunit/private/check-info.rkt
@@ -48,8 +48,6 @@
     [(pretty-info? info-value) (pretty-format (pretty-info-value info-value))]
     [(verbose-info? info-value)
      (info-value->string (verbose-info-value info-value))]
-    [(dynamic-info? info-value)
-     (info-value->string ((dynamic-info-proc info-value)))]
     [else (~s info-value)]))
 
 (define (trim-current-directory path)

--- a/rackunit-lib/rackunit/private/check-info.rkt
+++ b/rackunit-lib/rackunit/private/check-info.rkt
@@ -18,6 +18,7 @@
   [struct pretty-info ([value any/c])]
   [struct nested-info ([values (listof check-info?)])]
   [struct verbose-info ([value any/c])]
+  [struct dynamic-info ([proc (-> any/c)])]
   [info-value->string (-> any/c string?)]
   [current-check-info (parameter/c (listof check-info?))]
   [with-check-info* ((listof check-info?) (-> any) . -> . any)])
@@ -36,6 +37,7 @@
 (struct pretty-info (value) #:transparent)
 (struct verbose-info (value) #:transparent)
 (struct nested-info (values) #:transparent)
+(struct dynamic-info (proc) #:transparent)
 
 (define (info-value->string info-value)
   (cond
@@ -46,6 +48,8 @@
     [(pretty-info? info-value) (pretty-format (pretty-info-value info-value))]
     [(verbose-info? info-value)
      (info-value->string (verbose-info-value info-value))]
+    [(dynamic-info? info-value)
+     (info-value->string ((dynamic-info-proc info-value)))]
     [else (~s info-value)]))
 
 (define (trim-current-directory path)

--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -61,7 +61,12 @@
 (define (check-info->string info verbose? name-width)
   (define name (symbol->string (check-info-name info)))
   (define value (check-info-value info))
-  (cond [(nested-info? value)
+  (cond [(dynamic-info? value)
+         (define new-info
+           (make-check-info (check-info-name info)
+                            ((dynamic-info-proc value))))
+         (check-info->string new-info verbose? name-width)]
+        [(nested-info? value)
          (define nested-str (nested-info->string value verbose? name-width))
          (format "~a:\n~a" name nested-str)]
         [else

--- a/rackunit-lib/rackunit/private/test.rkt
+++ b/rackunit-lib/rackunit/private/test.rkt
@@ -19,10 +19,8 @@
          (struct-out rackunit-test-case)
          (struct-out rackunit-test-suite)
          (struct-out string-info)
-
-         nested-info
-         nested-info?
-         nested-info-values
+         (struct-out nested-info)
+         (struct-out dynamic-info)
 
          with-check-info
          with-check-info*

--- a/rackunit-test/tests/rackunit/all-rackunit-tests.rkt
+++ b/rackunit-test/tests/rackunit/all-rackunit-tests.rkt
@@ -2,7 +2,6 @@
 
 (require rackunit
          "check-test.rkt"
-         "format-test.rkt"
          "test-case-test.rkt"
          "test-suite-test.rkt"
          "base-test.rkt"
@@ -26,7 +25,6 @@
    test-tests
    util-tests
    text-ui-tests
-   format-tests
    ))
 
 (define failure-tests

--- a/rackunit-test/tests/rackunit/format-test.rkt
+++ b/rackunit-test/tests/rackunit/format-test.rkt
@@ -20,4 +20,31 @@
                 (thunk (display-check-info-stack
                         (list (make-check-name "foo")
                               (make-check-actual 1)
-                              (make-check-expected 2))))))
+                              (make-check-expected 2)))))
+  (test-case "string-info"
+    (check-output "name:       foo\n"
+                  (thunk (display-check-info-stack
+                          (list (make-check-info 'name (string-info "foo")))))))
+  (test-case "nested-info"
+    (check-output "name:\n  foo:        1\n  bar:        2\n"
+                  (thunk
+                   (display-check-info-stack
+                    (list (make-check-name
+                           (nested-info
+                            (list (make-check-info 'foo 1)
+                                  (make-check-info 'bar 2)))))))))
+  (test-case "dynamic-info"
+    (check-output "foo:        1\n"
+                  (thunk
+                   (display-check-info-stack
+                    (list (make-check-info 'foo (dynamic-info (thunk 1)))))))
+    (test-case "with-nested-info"
+      (check-output "name:\n  foo:        1\n  bar:        2\n"
+                    (thunk
+                     (display-check-info-stack
+                      (list (make-check-name
+                             (dynamic-info
+                              (thunk
+                               (nested-info
+                                (list (make-check-info 'foo 1)
+                                      (make-check-info 'bar 2)))))))))))))

--- a/rackunit-test/tests/rackunit/format-test.rkt
+++ b/rackunit-test/tests/rackunit/format-test.rkt
@@ -1,25 +1,23 @@
 #lang racket/base
 
-(require rackunit
+(require racket/function
+         racket/port
+         rackunit
          rackunit/private/check-info
          rackunit/private/format
          (submod rackunit/private/format for-test))
 
-(provide format-tests)
+(define-check (check-output expected thnk)
+  (define actual (with-output-to-string thnk))
+  (with-check-info* (list (make-check-actual actual)
+                          (make-check-expected expected))
+    (thunk
+     (unless (equal? actual expected)
+       (fail-check)))))
 
-(define format-tests
-  (test-suite
-   "All tests for format"
-
-   (test-case
-    "display-check-info-stack"
-    (let ([p (open-output-string)])
-      (parameterize ([current-output-port p])
-        (check string=?
-               (begin (display-check-info-stack
-                       (list (make-check-name "foo")
-                             (make-check-actual 1)
-                             (make-check-expected 2)))
-                      (get-output-string p))
-               "name:       \"foo\"\nactual:     1\nexpected:   2\n"))))
-   ))
+(test-case "display-check-info-stack"
+  (check-output "name:       \"foo\"\nactual:     1\nexpected:   2\n"
+                (thunk (display-check-info-stack
+                        (list (make-check-name "foo")
+                              (make-check-actual 1)
+                              (make-check-expected 2))))))


### PR DESCRIPTION
Closes #76 

Adds a `dynamic-info` struct that allows a check-info value to be computed at the time the stack is rendered into a string, rather than when the info is added to the stack. This makes it easy to add an info for a parameter such as `current-directory` to a group of tests without messing with `current-check-handler`.