### PR TITLE
define-check: only add location if not already on stack

### DIFF
--- a/rackunit-lib/info.rkt
+++ b/rackunit-lib/info.rkt
@@ -11,4 +11,4 @@
 
 (define pkg-authors '(ryanc noel))
 
-(define version "1.8")
+(define version "1.9")

--- a/rackunit-lib/rackunit/private/test.rkt
+++ b/rackunit-lib/rackunit/private/test.rkt
@@ -24,6 +24,7 @@
 
          with-check-info
          with-check-info*
+         with-default-check-info*
 
          make-check-name
          make-check-params


### PR DESCRIPTION
Change `define-check` to only add a location for the check if the `current-check-info` stack does not have a location on it.

(I think this is what `check-true` and others used to do. I'm not sure if they did the same for other check-info items too.)

#### With this PR,
this program fails with a good error message:
```
#lang racket/base
(require rackunit (for-syntax racket/base syntax/parse syntax/srcloc))

(define-syntax (check-true* stx)
  (syntax-parse stx
   [(_ . e*)
    #`(begin .
        #,(for/list ([e (in-list (syntax-e #'e*))])
            #`(with-check-info* (list (make-check-location '#,(build-source-location-list e)))
                (λ () (check-true #,e)))))]))

(check-true*
 #true
 #false)
```

#### Without this PR,
the above program needs to be rewritten something like this to get a good error message:
```
#lang racket/base
(require rackunit (for-syntax racket/base syntax/parse syntax/srcloc))

(define (call/updated-location loc thnk)
  (define old-around (current-check-around))
  (define (new-around check-thnk)
    (with-check-info* (list (make-check-location loc))
      (λ () (old-around check-thnk))))
  (parameterize ([current-check-around new-around])
    (thnk)))

(define-syntax (check-true* stx)
  (syntax-parse stx
    [(_ . e*)
    #`(begin .
        #,(for/list ([e (in-list (syntax-e #'e*))])
            #`(call/updated-location '#,(build-source-location-list e) (λ () (check-true #,e)))))]))

(check-true*
 #true
 #false)
```

- - -

In case we'd rather close this PR without merging, I looked in the main distribution for uses of `with-check-info` that updated the location. The only ones I found were in the `rackunit-abbrevs` and `typed-racket-test` collections. I can change those to do the `call/updated-location` dance.