### PR TITLE
check-exn: use long names

### DIFF
--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -167,8 +167,8 @@
                (list/if
                 (and (not (check-info-contains-key? 'message))
                      (make-check-message "Wrong exception raised"))
-                (make-check-info 'exn-message (exn-message exn))
-                (make-check-info 'exn exn))
+                (make-check-info 'exception-message (exn-message exn))
+                (make-check-info 'exception exn))
                (lambda () (fail-check))))])
         (thunk))
       (with-check-info*


### PR DESCRIPTION
'exn' => 'exception'

'exn-message' => 'exception-message'

Closes #88