### PR TITLE
doc: fix typos, change contract for 'message' arguments

### DIFF
--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -26,12 +26,12 @@ source locations if you do so.
 The following are the basic checks RackUnit provides.  You
 can create your own checks using @racket[define-check].
 
-@defproc*[([(check-eq? (v1 any) (v2 any) (message string? "")) void?]
-           [(check-not-eq? (v1 any) (v2 any) (message string? "")) void?]
-           [(check-eqv? (v1 any) (v2 any) (message string? "")) void?]
-           [(check-not-eqv? (v1 any) (v2 any) (message string? "")) void?]
-           [(check-equal? (v1 any) (v2 any) (message string? "")) void?]
-           [(check-not-equal? (v1 any) (v2 any) (message string? "")) void?])]{
+@defproc*[([(check-eq? (v1 any) (v2 any) (message (or/c string? #f) #f)) void?]
+           [(check-not-eq? (v1 any) (v2 any) (message (or/c string? #f) #f)) void?]
+           [(check-eqv? (v1 any) (v2 any) (message (or/c string? #f) #f)) void?]
+           [(check-not-eqv? (v1 any) (v2 any) (message (or/c string? #f) #f)) void?]
+           [(check-equal? (v1 any) (v2 any) (message (or/c string? #f) #f)) void?]
+           [(check-not-equal? (v1 any) (v2 any) (message (or/c string? #f) #f)) void?])]{
 
 Checks that @racket[v1] is equal (or not equal) to @racket[v2], using
 @racket[eq?], @racket[eqv?], or @racket[equal?], respectively. The
@@ -50,7 +50,7 @@ For example, the following checks all fail:
 ]
 }
 
-@defproc[(check-pred (pred (-> any any)) (v any) (message string? ""))
+@defproc[(check-pred (pred (-> any any)) (v any) (message (or/c string? #f) #f))
          void?]{
 
 Checks that @racket[pred] returns a value that is not @racket[#f] when
@@ -68,7 +68,7 @@ The following check fails:
 ]
 }
 
-@defproc[(check-= (v1 any) (v2 any) (epsilon number?) (message string? ""))
+@defproc[(check-= (v1 any) (v2 any) (epsilon number?) (message (or/c string? #f) #f))
          void?]{
 
 Checks that @racket[v1] and @racket[v2] are numbers within
@@ -87,9 +87,9 @@ The following check fails:
 ]
 }
 
-@defproc*[([(check-true (v any) (message string? "")) void?]
-           [(check-false (v any) (message string? "")) void?]
-           [(check-not-false (v any) (message string? "")) void?])]{
+@defproc*[([(check-true (v any) (message (or/c string? #f) #f)) void?]
+           [(check-false (v any) (message (or/c string? #f) #f)) void?]
+           [(check-not-false (v any) (message (or/c string? #f) #f)) void?])]{
 
 Checks that @racket[v] is @racket[#t], is @racket[#f], or is not
 @racket[#f], respectively.  The optional @racket[message] is included
@@ -105,7 +105,7 @@ For example, the following checks all fail:
 }
 
 @defproc[(check-exn (exn-predicate (or/c (-> any any/c) regexp?))
-                    (thunk (-> any)) (message string? ""))
+                    (thunk (-> any)) (message (or/c string? #f) #f))
          void?]{
 
 Checks that @racket[thunk] raises an exception and that either
@@ -150,7 +150,7 @@ entirely.
 ]
 }
 
-@defproc[(check-not-exn (thunk (-> any)) (message string? "")) void?]{
+@defproc[(check-not-exn (thunk (-> any)) (message (or/c string? #f) #f)) void?]{
 
 Checks that @racket[thunk] does not raise any exceptions.
 The optional @racket[message] is included in the output if
@@ -228,7 +228,7 @@ This check fails because of a failure to match:
 @defproc[(check (op (-> any any any))
                 (v1 any)
                 (v2 any)
-                (message string? ""))
+                (message (or/c string? #f) #f))
          void?]{
 
 The most generic check.  Succeeds if @racket[op] applied to
@@ -249,7 +249,7 @@ The following check fails:
 ]
 }
 
-@defproc[(fail (message string? ""))
+@defproc[(fail (message (or/c string? #f) #f))
          void?]{
 
 This check fails unconditionally.  Good for creating test stubs that

--- a/rackunit-doc/rackunit/scribblings/overview.scrbl
+++ b/rackunit-doc/rackunit/scribblings/overview.scrbl
@@ -8,7 +8,7 @@ There are three basic concepts in RackUnit:
 @itemize[
 
 @item{A @italic{check} is the basic unit of a test.  As the name
-suggests, it checks some condition is true.}
+suggests, it checks whether some condition is true.}
 
 @item{A @italic{test case} is a group of checks that form one
 conceptual unit.  If any check within the case fails, the entire case

--- a/rackunit-doc/rackunit/scribblings/ui.scrbl
+++ b/rackunit-doc/rackunit/scribblings/ui.scrbl
@@ -20,7 +20,7 @@ It is run via the @racket[run-tests] function.
 
 The given @racket[test] is run and the result of running it
 output to the @racket[current-output-port].  The output is
-compatable with the (X)Emacs next-error command (as used,
+compatible with the (X)Emacs next-error command (as used,
 for example, by (X)Emacs's compile function)
 
 The optional @racket[verbosity] is one of @racket['quiet],

--- a/rackunit-test/tests/rackunit/pr/90.rkt
+++ b/rackunit-test/tests/rackunit/pr/90.rkt
@@ -1,0 +1,56 @@
+#lang racket/base
+
+;; Test the optional `message` argument to checks:
+;; - if "", output contains ""
+;; - if #f, output nothing
+;; - if unsupplied, output nothing
+
+(require rackunit
+         rackunit/text-ui
+         racket/port
+         tests/eli-tester)
+
+;; --- setup
+
+;; Test check forms with no message, #f message, and "" message
+(define-syntax-rule (test-check/empty-message (check-name arg* ...) ...)
+  (begin
+    (begin
+      (test (not (regexp-match? #rx"message:" (capture-output (check-name arg* ...)))))
+      (test (not (regexp-match? #rx"message:" (capture-output (check-name arg* ... #f)))))
+      (test (regexp-match? #rx"message: *\"\"" (capture-output (check-name arg* ... "")))))
+    ...))
+
+;; Evaluate `expr`, return string with error output
+(define-syntax-rule (capture-output expr)
+  (with-output-to-string
+    (lambda ()
+      (parameterize ([current-error-port (current-output-port)])
+        expr))))
+
+;; --- actual tests
+
+(test-check/empty-message
+  (check-eq? 'a 'b)
+  (check-not-eq? 0 0)
+  (check-eqv? 'a 'b)
+  (check-not-eqv? 0 0)
+  (check-equal? 'a 'b)
+  (check-not-equal? 0 0)
+  (check-pred values #f)
+  (check-= 0 1 0)
+  (check-true #false)
+  (check-false #true)
+  (check-not-false #false)
+  (check = 1 2)
+  (fail)
+)
+
+;; --- copied from "../pr10950.rkt"
+
+(module test racket/base
+  (require syntax/location)
+  ;; Use a separate namespace to avoid logging results
+  ;; in this namespace (where `raco test` would see errors).
+  (parameterize ([current-namespace (make-base-namespace)])
+    (dynamic-require (quote-module-path "..") #f)))


### PR DESCRIPTION
If the 'message' is `#f` there is no message, if 'message' is `""` then it gets printed as the message.n