### PR TITLE
fix indentation for long pretty-info values

### DIFF
--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -2,6 +2,7 @@
 (require racket/list
          racket/match
          racket/string
+         racket/pretty
          "base.rkt"
          "check-info.rkt")
 
@@ -17,6 +18,7 @@
 (define minimum-name-width 9)
 
 (define nested-indent-amount 2)
+(define multi-line-indent-amount 2)
 
 (define (display-test-result res
                              #:verbose? [verbose? #f]
@@ -71,7 +73,16 @@
          (format "~a:\n~a" name nested-str)]
         [else
          (define pad (string-padding name name-width))
-         (format "~a:~a  ~a" name pad (info-value->string value))]))
+         (define one-line-candidate
+           (parameterize ([pretty-print-columns 'infinity])
+             (format "~a:~a  ~a" name pad (info-value->string value))))
+         (if (<= (string-length one-line-candidate) (pretty-print-columns))
+             one-line-candidate
+             (format "~a:\n~a"
+                     name
+                     (string-indent
+                      (info-value->string value)
+                      multi-line-indent-amount)))]))
 
 (define (nested-info->string nested verbose? name-width)
   (define infos (nested-info-values nested))

--- a/rackunit-test/tests/rackunit/text-ui-test.rkt
+++ b/rackunit-test/tests/rackunit/text-ui-test.rkt
@@ -78,6 +78,15 @@
                (check-false
                 (list (iota 15) (iota 15) (iota 15)))))))
 
+(define (failing-test/issue-91)
+  (run-tests
+   (test-suite
+    "Dummy"
+    (test-case "Dummy"
+               (check-equal?
+                (make-list 10 'xfdjkalf)
+                (make-list 11 'xfdjkalf))))))
+
 (define (quiet-failing-test)
   (run-tests
    (test-suite
@@ -132,6 +141,37 @@
              "  '(((0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
      (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
      (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)))")))
+
+   (test-case
+    "Pretty printing test from github issue #91"
+     (let ([op (parameterize ([pretty-print-columns 80])
+                 (with-all-output-to-string (failing-test/issue-91)))])
+       (check string-contains
+              op
+              "
+actual:
+  '(xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf)
+expected:
+  '(xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf
+    xfdjkalf)")))
    
    (test-case
     "Location trimmed when file is under current directory"

--- a/rackunit-test/tests/rackunit/text-ui-test.rkt
+++ b/rackunit-test/tests/rackunit/text-ui-test.rkt
@@ -119,9 +119,9 @@
                 (with-all-output-to-string (failing-binary-test/complex-params)))])
       (check string-contains
              op
-             "'((0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
-  (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
-  (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14))")))
+             "  '((0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
+    (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
+    (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14))")))
    
    (test-case
     "Non-binary check output is pretty printed"
@@ -129,9 +129,9 @@
                 (with-all-output-to-string (failing-test/complex-params)))])
       (check string-contains
              op
-             "'(((0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
-   (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
-   (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)))")))
+             "  '(((0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
+     (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
+     (0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)))")))
    
    (test-case
     "Location trimmed when file is under current directory"


### PR DESCRIPTION
Fixes #91.

The example there now produces:
```racket
--------------------
. FAILURE
name:       check-equal?
location:   unsaved-editor:11:0
actual:
  '(xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf)
expected:
  '(xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf
    xfdjkalf)
--------------------
```
With each `xfdjkalf` aligned with the one before it.