### PR TITLE
add empty rackunit-typed package for earlier racket versions

### DIFF
--- a/rackunit-typed/info.rkt
+++ b/rackunit-typed/info.rkt
@@ -1,0 +1,10 @@
+#lang info
+
+(define collection 'multi)
+
+(define deps
+  '("base"))
+
+(define implies
+  '("typed-racket-more"))
+


### PR DESCRIPTION
When earlier racket installations (6.10 and below) look for the `rackunit-typed` package, they currently find the main non-empty rackunit-typed package in the catalog. This creates a conflict with `typed-racket-more`, with them both trying to provide different versions of `typed/rackunit`. This pull request adds a dummy rackunit-typed package that earlier racket versions can point to.

The [catalog entry for `rackunit-typed`](https://pkgd.racket-lang.org/pkgn/package/rackunit-typed) should also have version exceptions for versions 6.10 and below pointing to the package source:
```
git://github.com/racket/rackunit?path=rackunit-typed#for-v-up-to-6.10
```