### PR TITLE
rackunit-typed for up to 6.10: add pkg-desc and pkg-authors

### DIFF
--- a/rackunit-typed/info.rkt
+++ b/rackunit-typed/info.rkt
@@ -9,3 +9,7 @@
 (define implies
   '("typed-racket-more"))
 
+(define pkg-desc "Typed Racket types for RackUnit")
+
+(define pkg-authors '(samth stamourv))
+


### PR DESCRIPTION
This PR defines `pkg-desc` and `pkg-authors` in the info.rkt file for the "empty" rackunit-typed package for versions when typed rackunit was still part of typed-racket-more.

See https://github.com/racket/rackunit/pull/93#issuecomment-379511027.

Are these values correct? And is there anything else that the catalog or Travis might require?