### PR TITLE
report arity errors in terms of the public API

### DIFF
--- a/rackunit-test/tests/rackunit/pr/100.rkt
+++ b/rackunit-test/tests/rackunit/pr/100.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+(require rackunit)
+
+(module+ test
+  (define ((arity-exn/rx rx) e)
+    (and (exn:fail:contract:arity? e)
+         (regexp-match? rx (exn-message e))))
+
+  (check-exn (arity-exn/rx #rx"check-exn")
+             (lambda () (check-exn (lambda () 'hi))))
+  (check-exn (arity-exn/rx #rx"check-true")
+             (lambda () (check-true 1 2 3 4)))
+  (check-exn (arity-exn/rx #rx"check-equal\\?")
+             (lambda () (check-equal? (list 1 2))))
+
+  (let ([cp check-pred])
+    (check-true (procedure-arity-includes? cp 2))
+    (check-true (procedure-arity-includes? cp 3))
+    (check-false (procedure-arity-includes? cp 0))
+    (check-false (procedure-arity-includes? cp 1))
+    (check-false (procedure-arity-includes? cp 4))))


### PR DESCRIPTION
Fix for #99 

Now this program:

```
#lang racket

(require rackunit)
(check-exn (lambda () 'hi))
```

Errors with:

```
check-exn: arity mismatch;
 the expected number of arguments does not match the given number
  given: 1
  arguments...:
   #<procedure:...rackunit/foo.rkt:4:11>
  context...:
   "/..../rackunit/foo.rkt": [running body]
   for-loop
   run-module-instance!125
   perform-require!78
```
- - -

This still needs a regression test. (EDIT: added a test)

But also, I'm not happy adding an extra `lambda` to get the keyword arguments. Suggestions welcome.