### PR TITLE
rackunit/docs-complete: accept any `module-path?`

### DIFF
--- a/rackunit-doc/rackunit/scribblings/utils.scrbl
+++ b/rackunit-doc/rackunit/scribblings/utils.scrbl
@@ -10,7 +10,7 @@
 @section{Checking documentation completeness}
 @defmodule[rackunit/docs-complete]
 
-@defproc[(check-docs [lib symbol?]
+@defproc[(check-docs [lib module-path?]
                      [#:skip skip 
                              (or/c regexp? 
                                    symbol?


### PR DESCRIPTION
This pull request updates the documentation to correspond to https://github.com/racket/racket/pull/2230