### PR TITLE
Treat exceptions thrown by arguments to check as test failures

### DIFF
--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -121,6 +121,8 @@
            (display-raised-message e)]
           [else
            (display-raised-summary "ERROR" e)
+           (display-check-info-stack (current-check-info)
+                                     #:verbose? verbose?)
            (display-raised-message e)])
     (display-delimiter)))
 


### PR DESCRIPTION
Problem
-------

Rackunit family of `check` macros, as they are implemented atm, exhibit an
unfortunate behavior where they lose all context and report no location of failed
checks when the code being tested raises exceptions. Picture a typical rkt source
file with test-modules freely interspersed with code. In a check like this:

  (check eq? (f) 42)

if f ever throws, the exception will be propagated to the programmer without much
detail and worse without any indication as to which check (perhaps of hundreds)
raised an error. Location is neither captured nor reported. Triaging such failures
quickly turns into a bisecting expedition that may be a lot of work when your have
many tests in the same file.

Here's the mechanics as I understand it. Rackunit checks are defined with
`define-check` macro, which takes a bunch of arguments and a check body that
constitutes the computation that decides whether the check succeeds or fails. The
macro constructs a function that performs said computation with the body wrapped
in additional context e.g. location and name of the check, so that installed
handlers can communicate the failure to the programmer. That usually works well,
however, since checks are really glorified functions they eval their arguments
eagerly. As it happens in your typical check most of the user code runs before it
ever reaches the body. During the evaluation of the arguments to the check
function no context is collected, nor does the branch that handles such errors
attempt to report anything beyond the error message (see
`display-test-failure/error` in format.rkt).

This issue has been discussed at some length on the mailing list:
https://groups.google.com/d/msg/racket-users/aCQwqCTY42U/NRZ_AU_YBwAJ

Proposed solution
-----------------

Delay argument evaluation in checks by wrapping each in a thunk, then force the
thunks in the body of a check so that any expression passed to the check runs
within a context that can be reported to the programmer.

I believe this won't break your typical use case of _rackunit_ and no user code 
would have to change. This may not be true of any library that builds on top of 
rackunit.