### PR TITLE
Change any to any/c where appropriate (fixes #106)

### DIFF
--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -130,7 +130,7 @@ For example, the following checks all fail:
 ]
 }
 
-@defproc[(check-exn (exn-predicate (or/c (-> any/c any/c) regexp?))
+@defproc[(check-exn (exn-predicate (or/c (-> any/c any) regexp?))
                     (thunk (-> any)) (message (or/c string? #f) #f))
          void?]{
 

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -130,7 +130,7 @@ For example, the following checks all fail:
 ]
 }
 
-@defproc[(check-exn (exn-predicate (or/c (-> any/c any) regexp?))
+@defproc[(check-exn (exn-predicate (or/c (-> any/c any/c) regexp?))
                     (thunk (-> any)) (message (or/c string? #f) #f))
          void?]{
 

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -28,12 +28,12 @@ function, though this will affect the source location that the check grabs.
 The following are the basic checks RackUnit provides.  You
 can create your own checks using @racket[define-check].
 
-@defproc*[([(check-eq? (v1 any) (v2 any) (message (or/c string? #f) #f)) void?]
-           [(check-not-eq? (v1 any) (v2 any) (message (or/c string? #f) #f)) void?]
-           [(check-eqv? (v1 any) (v2 any) (message (or/c string? #f) #f)) void?]
-           [(check-not-eqv? (v1 any) (v2 any) (message (or/c string? #f) #f)) void?]
-           [(check-equal? (v1 any) (v2 any) (message (or/c string? #f) #f)) void?]
-           [(check-not-equal? (v1 any) (v2 any) (message (or/c string? #f) #f)) void?])]{
+@defproc*[([(check-eq? (v1 any/c) (v2 any/c) (message (or/c string? #f) #f)) void?]
+           [(check-not-eq? (v1 any/c) (v2 any/c) (message (or/c string? #f) #f)) void?]
+           [(check-eqv? (v1 any/c) (v2 any/c) (message (or/c string? #f) #f)) void?]
+           [(check-not-eqv? (v1 any/c) (v2 any/c) (message (or/c string? #f) #f)) void?]
+           [(check-equal? (v1 any/c) (v2 any/c) (message (or/c string? #f) #f)) void?]
+           [(check-not-equal? (v1 any/c) (v2 any/c) (message (or/c string? #f) #f)) void?])]{
 
 Checks that @racket[v1] is equal (or not equal) to @racket[v2], using
 @racket[eq?], @racket[eqv?], or @racket[equal?], respectively. The
@@ -52,7 +52,7 @@ For example, the following checks all fail:
 ]
 }
 
-@defproc[(check-pred (pred (-> any any)) (v any) (message (or/c string? #f) #f))
+@defproc[(check-pred (pred (-> any/c any)) (v any/c) (message (or/c string? #f) #f))
          void?]{
 
 Checks that @racket[pred] returns a value that is not @racket[#f] when
@@ -89,7 +89,7 @@ The following check fails:
 ]
 }
 
-@defproc[(check-within [v1 any] [v2 any] [epsilon number?] [message (or/c string? #f) #f])
+@defproc[(check-within [v1 any/c] [v2 any/c] [epsilon number?] [message (or/c string? #f) #f])
          void?]{
 
 Checks that @racket[v1] and @racket[v2] are @racket[equal?] to each
@@ -113,9 +113,9 @@ And the following checks fail:
 
 @history[#:added "1.10"]}
 
-@defproc*[([(check-true (v any) (message (or/c string? #f) #f)) void?]
-           [(check-false (v any) (message (or/c string? #f) #f)) void?]
-           [(check-not-false (v any) (message (or/c string? #f) #f)) void?])]{
+@defproc*[([(check-true (v any/c) (message (or/c string? #f) #f)) void?]
+           [(check-false (v any/c) (message (or/c string? #f) #f)) void?]
+           [(check-not-false (v any/c) (message (or/c string? #f) #f)) void?])]{
 
 Checks that @racket[v] is @racket[#t], is @racket[#f], or is not
 @racket[#f], respectively.  The optional @racket[message] is included
@@ -130,7 +130,7 @@ For example, the following checks all fail:
 ]
 }
 
-@defproc[(check-exn (exn-predicate (or/c (-> any any/c) regexp?))
+@defproc[(check-exn (exn-predicate (or/c (-> any/c any/c) regexp?))
                     (thunk (-> any)) (message (or/c string? #f) #f))
          void?]{
 
@@ -251,9 +251,9 @@ This check fails because of a failure to match:
 }
 
 
-@defproc[(check (op (-> any any any))
-                (v1 any)
-                (v2 any)
+@defproc[(check (op (-> any/c any/c any))
+                (v1 any/c)
+                (v2 any/c)
                 (message (or/c string? #f) #f))
          void?]{
 
@@ -290,7 +290,7 @@ the failure to RackUnit's @tech{check-info stack}.
 Additional information can be stored by using the @racket[with-check-info*]
 function, and the @racket[with-check-info] macro.
 
-@defstruct[check-info ([name symbol?] [value any]) #:transparent]{
+@defstruct[check-info ([name symbol?] [value any/c]) #:transparent]{
  A @deftech[#:key "check-info"]{check-info structure} stores information
  associated with the context of the execution of a check. The @racket[value]
  is normally written in a check failure message using @racket[write], but the
@@ -363,14 +363,14 @@ structures with predefined names.  This avoids
 misspelling errors:
 
 @defproc*[([(make-check-name (name string?)) check-info?]
-           [(make-check-params (params (listof any))) check-info?]
-           [(make-check-location (loc (list/c any (or/c number? #f) (or/c number? #f)
+           [(make-check-params (params (listof any/c))) check-info?]
+           [(make-check-location (loc (list/c any/c (or/c number? #f) (or/c number? #f)
                                                   (or/c number? #f) (or/c number? #f))))
             check-info?]
-           [(make-check-expression (msg any)) check-info?]
+           [(make-check-expression (msg any/c)) check-info?]
            [(make-check-message (msg string?)) check-info?]
-           [(make-check-actual (param any)) check-info?]
-           [(make-check-expected (param any)) check-info?])]{}
+           [(make-check-actual (param any/c)) check-info?]
+           [(make-check-expected (param any/c)) check-info?])]{}
 
 @defproc[(with-check-info* (info (listof check-info?)) (thunk (-> any))) any]{
 

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -52,7 +52,7 @@ For example, the following checks all fail:
 ]
 }
 
-@defproc[(check-pred (pred (-> any/c any)) (v any/c) (message (or/c string? #f) #f))
+@defproc[(check-pred (pred (-> any/c any/c)) (v any/c) (message (or/c string? #f) #f))
          void?]{
 
 Checks that @racket[pred] returns a value that is not @racket[#f] when
@@ -251,7 +251,7 @@ This check fails because of a failure to match:
 }
 
 
-@defproc[(check (op (-> any/c any/c any))
+@defproc[(check (op (-> any/c any/c any/c))
                 (v1 any/c)
                 (v2 any/c)
                 (message (or/c string? #f) #f))

--- a/rackunit-doc/rackunit/scribblings/compound-testing.scrbl
+++ b/rackunit-doc/rackunit/scribblings/compound-testing.scrbl
@@ -47,7 +47,7 @@ so the test can be named.
 ]
 
 
-@defproc[(test-case? (obj any)) boolean?]{
+@defproc[(test-case? (obj any/c)) boolean?]{
  True if @racket[obj] is a test case, and false otherwise.
 }
 
@@ -69,7 +69,7 @@ so the test can be named.
            [(test-true [name string?] [v any/c]) void?]
            [(test-false [name string?] [v any/c]) void?]
            [(test-not-false [name string?] [v any/c]) void?]
-           [(test-exn [name string?] [pred (or/c (-> any any/c) regexp?)] [thunk (-> any)]) void?]
+           [(test-exn [name string?] [pred (or/c (-> any/c any) regexp?)] [thunk (-> any)]) void?]
            [(test-not-exn [name string?] [thunk (-> any)]) void?])]{
 
 Creates a test case with the given @racket[name] that performs the
@@ -136,7 +136,7 @@ given @racket[tests]. Unlike the @racket[test-suite] form, the tests
 are represented as a list of test values.
 }
 
-@defproc[(test-suite? (obj any)) boolean?]{ True if
+@defproc[(test-suite? (obj any/c)) boolean?]{ True if
 @racket[obj] is a test suite, and false otherwise}
 
 

--- a/rackunit-doc/rackunit/scribblings/compound-testing.scrbl
+++ b/rackunit-doc/rackunit/scribblings/compound-testing.scrbl
@@ -69,7 +69,7 @@ so the test can be named.
            [(test-true [name string?] [v any/c]) void?]
            [(test-false [name string?] [v any/c]) void?]
            [(test-not-false [name string?] [v any/c]) void?]
-           [(test-exn [name string?] [pred (or/c (-> any/c any) regexp?)] [thunk (-> any)]) void?]
+           [(test-exn [name string?] [pred (or/c (-> any/c any/c) regexp?)] [thunk (-> any)]) void?]
            [(test-not-exn [name string?] [thunk (-> any)]) void?])]{
 
 Creates a test case with the given @racket[name] that performs the


### PR DESCRIPTION
Using `any` is a syntax error in non-return position.
This PR corrects this mistake in the documentation.
Note that the change is conservative: I only fix the cases that
are definitely incorrect, but there could still be incorrect
ones left.