### PR TITLE
Treat exceptions thrown by arguments to check as test failures, without changing function behavior

### DIFF
--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -104,6 +104,7 @@
           (with-default-check-info* infos
             (λ () ((current-check-around) (λ () body ... (void))))))
       'pub)))
+                                      
 
 (define-simple-macro (define-check (name:id formal:id ...) body:expr ...)
   (begin
@@ -112,9 +113,16 @@
       (with-syntax ([loc (datum->syntax #f 'loc stx)])
         (syntax-parse stx
           [(chk . args)
-           #'((check-impl #:location (syntax->location #'loc)
-                          #:expression '(chk . args))
-              . args)]
+           #'(let ([location (syntax->location #'loc)])
+               (with-default-check-info*
+                (list (make-check-name 'name)
+                      (make-check-location location)
+                      (make-check-expression '(chk . args)))
+                (λ ()
+                  ((current-check-around)
+                   (λ () ((check-impl #:location location
+                                      #:expression '(chk . args))
+                          . args))))))]
           [chk:id
            #'(check-impl #:location (syntax->location #'loc)
                          #:expression 'chk)])))))

--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -121,6 +121,8 @@
            (display-raised-message e)]
           [else
            (display-raised-summary "ERROR" e)
+           (display-check-info-stack (current-check-info)
+                                     #:verbose? verbose?)
            (display-raised-message e)])
     (display-delimiter)))
 

--- a/rackunit-test/tests/rackunit/standalone.rkt
+++ b/rackunit-test/tests/rackunit/standalone.rkt
@@ -41,6 +41,8 @@
            #"\
 --------------------
 ERROR
+name:       check-pred
+location:   standalone-check-test.rkt:44:0
 
 Outta here!
 --------------------
@@ -59,11 +61,13 @@ message:    0.0
 --------------------
 ERROR
 
+
 First Outta here!
 --------------------
 --------------------
 error
 ERROR
+
 
 Second Outta here!
 --------------------


### PR DESCRIPTION
Just like #107, this PR has the goal of catching errors thrown by arguments and turning them into check failures. However unlike #107, this one does not change the behavior of checks when used as function-ids.