### PR TITLE
try fixing CI

### DIFF
--- a/rackunit-typed/info.rkt
+++ b/rackunit-typed/info.rkt
@@ -5,8 +5,7 @@
 (define test-responsibles '((all jay)))
 
 (define deps
-  '("racket-index"
-    "rackunit-gui"
+  '("rackunit-gui"
     "rackunit-lib"
     "typed-racket-lib"
     "base"


### PR DESCRIPTION
- first, trying to remove a dependency
- second idea: change the `.travis.yml` to use `--no-setup`?
- third idea: look at `racket-index` ... try to debug the travis error:

```
instantiate: unknown module
  module name: #<resolved-module-path:"/home/travis/.racket/snapshot/pkgs/scribble-lib/scribble/xref.rkt">
  compilation context...:
   /home/travis/.racket/snapshot/pkgs/racket-index/scribblings/main/local-redirect.scrbl
  context...:
   namespace-module-instantiate!96
   for-loop
   [repeats 1 more time]
   run-module-instance!125
   for-loop
   [repeats 1 more time]
   run-module-instance!125
   perform-require!78
   for-loop
   finish
   [repeats 1 more time]
   pass-1-and-2-loop
   module-begin-k
   expand-module16
   expand-capturing-lifts
   temp118_0
   ...
```