### PR TITLE
check-compile-time-exn implementation for compile time exception testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ doc/
 .DS_Store
 *.bak
 TAGS
+
+pkgs-catalog
+
+catalog-config.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 - raco pkg config catalogs >> catalog-config.txt
 - raco pkg config --set catalogs `cat catalog-config.txt`
 - raco pkg install --auto $PKG-test
-- raco pkg install --auto $PKG-typed
+- raco pkg install --auto $PKG-typed || true
 - raco pkg install --auto compiler-lib
 - ls $HOME/.racket/download-cache
 

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -178,7 +178,7 @@ entirely.
 
 @defform[(check-compile-time-exn exn-predicate body)
          #:contracts ([exn-predicate (or/c (-> any/c any/c) regexp?)]
-                      [body (-> any)])
+                      [body (-> any/c)])
          void?]{
 
 Similar to @racket[check-exn], but checks that an expression, @racket[body],

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -188,15 +188,6 @@ message in the exception if  @racket[exn-predicate] is a regexp.
 In the latter case, the exception raised must be an @racket[exn:fail?].
 }
 
-@defform[(check-syntax-exn exn-predicate body)
-         #:contracts ([exn-predicate (or/c (-> any/c any/c) regexp?)]
-                      [body (-> any)])
-         void?]{
-
-Same as @racket[check-compile-time-exn], but only catches compile-time
-@racket[exn:fail:syntax?] exceptions and runtime exceptions in @racket[body].
-}
-
 @defproc[(check-not-exn (thunk (-> any)) (message (or/c string? #f) #f)) void?]{
 
 Checks that @racket[thunk] does not raise any exceptions.
@@ -216,14 +207,6 @@ the check fails.
 
 Similar to @racket[check-not-exn], but checks that an expression, @racket[body],
 does not raise a runtime or compile time exception.
-}
-
-@defform[(check-not-syntax-exn body)
-          #:contracts ([body (-> any)])
-          void?]{
-
-Same as @racket[check-not-compile-time-exn], but only catches compile-time
-@racket[exn:fail:syntax?] exceptions and runtime exceptions in @racket[body].
 }
 
 @defproc[(check-regexp-match (regexp regexp?)

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -176,19 +176,26 @@ entirely.
 ]
 }
 
-@defproc[(check-compile-time-exn (exn-predicate (or/c (-> any/c any/c) regexp?))
-                    (thunk (-> any)) (message (or/c string? #f) #f))
+@defform[(check-compile-time-exn exn-predicate body)
+         #:contracts ([exn-predicate (or/c (-> any/c any/c) regexp?)]
+                      [body (-> any)])
          void?]{
 
-Same as @racket[check-exn], but wraps @racket[thunk] with 
-@racket[convert-compile-time-error] to check for compile time exceptions.
+Similar to @racket[check-exn], but checks that an expression, @racket[body],
+raises a runtime or compile time exception and that either @racket[exn-predicate] 
+returns a true value if it is a function, or that it matches the 
+message in the exception if  @racket[exn-predicate] is a regexp. 
+In the latter case, the exception raised must be an @racket[exn:fail?].
+}
 
-@defproc[(check-syntax-exn (exn-predicate (or/c (-> any/c any/c) regexp?))
-                    (thunk (-> any)) (message (or/c string? #f) #f))
+@defform[(check-syntax-exn exn-predicate body)
+         #:contracts ([exn-predicate (or/c (-> any/c any/c) regexp?)]
+                      [body (-> any)])
          void?]{
 
-Same as @racket[check-exn], but wraps @racket[thunk] with 
-@racket[convert-syntax-error] to check for compile time syntax exceptions.
+Same as @racket[check-compile-time-exn], but only catches compile-time
+@racket[exn:fail:syntax?] exceptions and runtime exceptions in @racket[body].
+}
 
 @defproc[(check-not-exn (thunk (-> any)) (message (or/c string? #f) #f)) void?]{
 
@@ -203,17 +210,21 @@ the check fails.
 
 }
 
-@defproc[(check-not-compile-time-exn (thunk (-> any)) (message (or/c string? #f) #f)) void?]{
+@defform[(check-not-compile-time-exn body)
+          #:contracts ([body (-> any)])
+          void?]{
 
-Same as @racket[check-not-exn], but wraps @racket[thunk] with 
-@racket[convert-compile-time-error] to check that there are no
-compile time exceptions.
+Similar to @racket[check-not-exn], but checks that an expression, @racket[body],
+does not raise a runtime or compile time exception.
+}
 
-@defproc[(check-not-syntax-exn (thunk (-> any)) (message (or/c string? #f) #f)) void?]{
+@defform[(check-not-syntax-exn body)
+          #:contracts ([body (-> any)])
+          void?]{
 
-Same as @racket[check-not-exn], but wraps @racket[thunk] with 
-@racket[convert-syntax-error] to check that there are no
-compile time syntax exceptions.
+Same as @racket[check-not-compile-time-exn], but only catches compile-time
+@racket[exn:fail:syntax?] exceptions and runtime exceptions in @racket[body].
+}
 
 @defproc[(check-regexp-match (regexp regexp?)
                              (string string?))

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -176,6 +176,20 @@ entirely.
 ]
 }
 
+@defproc[(check-compile-time-exn (exn-predicate (or/c (-> any/c any/c) regexp?))
+                    (thunk (-> any)) (message (or/c string? #f) #f))
+         void?]{
+
+Same as @racket[check-exn], but wraps @racket[thunk] with 
+@racket[convert-compile-time-error] to check for compile time exceptions.
+
+@defproc[(check-syntax-exn (exn-predicate (or/c (-> any/c any/c) regexp?))
+                    (thunk (-> any)) (message (or/c string? #f) #f))
+         void?]{
+
+Same as @racket[check-exn], but wraps @racket[thunk] with 
+@racket[convert-syntax-error] to check for compile time syntax exceptions.
+
 @defproc[(check-not-exn (thunk (-> any)) (message (or/c string? #f) #f)) void?]{
 
 Checks that @racket[thunk] does not raise any exceptions.
@@ -188,6 +202,18 @@ the check fails.
                     (check-not-exn (λ () (/ 1 0)) "don't divide by 0")]
 
 }
+
+@defproc[(check-not-compile-time-exn (thunk (-> any)) (message (or/c string? #f) #f)) void?]{
+
+Same as @racket[check-not-exn], but wraps @racket[thunk] with 
+@racket[convert-compile-time-error] to check that there are no
+compile time exceptions.
+
+@defproc[(check-not-syntax-exn (thunk (-> any)) (message (or/c string? #f) #f)) void?]{
+
+Same as @racket[check-not-exn], but wraps @racket[thunk] with 
+@racket[convert-syntax-error] to check that there are no
+compile time syntax exceptions.
 
 @defproc[(check-regexp-match (regexp regexp?)
                              (string string?))

--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -185,13 +185,16 @@
   (check-exn-helper raw-pred thunk null ))
        
 (define-syntax (check-compile-time-exn stx)
-  (with-syntax ([loc (datum->syntax #f 'loc stx)])
-     (syntax-parse stx
-       [(_ raw-pred body)
-        (syntax/loc stx (check-exn-helper raw-pred
+  (syntax-parse stx
+       [(_ body ...+)
+        (with-syntax ([loc (datum->syntax #f 'loc stx)])
+                     (syntax/loc stx
+                                (check-exn exn:fail?
                                           (lambda ()
-                                             (convert-compile-time-error body))
-                                          (syntax->location #'loc)))])))
+                                            (convert-compile-time-error (lambda ()
+                                                                            body ...
+                                                                            (void))))
+                                          (syntax->location #'loc))))]))
 
 (define-check (check-not-exn-helper thunk location)
   (raise-error-if-not-thunk 'check-not-exn thunk)
@@ -215,12 +218,15 @@
   (check-not-exn-helper thunk null))
   
 (define-syntax (check-not-compile-time-exn stx)
-  (with-syntax ([loc (datum->syntax #f 'loc stx)])
-     (syntax-parse stx
-       [(_ body)
-        (syntax/loc stx (check-not-exn-helper (lambda ()
-                                                 (convert-compile-time-error body))
-                                              (syntax->location #'loc)))])))
+  (syntax-parse stx
+       [(_ body ...+)
+        (with-syntax ([loc (datum->syntax #f 'loc stx)])
+                     (syntax/loc stx
+                                (check-not-exn (lambda ()
+                                                  (convert-compile-time-error (lambda ()
+                                                                                  body ...
+                                                                                  (void))))
+                                          (syntax->location #'loc))))]))
 
 (define-syntax-rule (define-simple-check-values [header body ...] ...)
   (begin (define-simple-check header body ...) ...))

--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -7,6 +7,7 @@
          racket/match
          rackunit/log
          syntax/parse/define
+         syntax/macro-testing
          "base.rkt"
          "equal-within.rkt"
          "check-info.rkt"
@@ -28,7 +29,11 @@
 
          check
          check-exn
+         check-compile-time-exn
+         check-syntax-exn
          check-not-exn
+         check-not-compile-time-exn
+         check-not-syntax-exn
          check-true
          check-false
          check-pred
@@ -173,6 +178,20 @@
       (with-default-check-info*
        (list (make-check-message "No exception raised"))
        (lambda () (fail-check))))))
+       
+(define-syntax check-compile-time-exn
+  (syntax-rules ()
+    ((_ raw-pred thunk)
+     (check-exn raw-pred
+                (lambda () 
+                   (convert-compile-time-error thunk))))))
+                   
+(define-syntax check-syntax-exn
+ (syntax-rules ()
+   ((_ raw-pred thunk)
+    (check-exn raw-pred
+               (lambda () 
+                  (convert-syntax-error thunk))))))
 
 (define-check (check-not-exn thunk)
   (raise-error-if-not-thunk 'check-not-exn thunk)
@@ -187,6 +206,18 @@
             (make-check-info 'exception exn))
            (lambda () (fail-check))))])
     (thunk)))
+    
+(define-syntax check-not-compile-time-exn
+ (syntax-rules ()
+   ((_ thunk)
+    (check-not-exn (lambda () 
+                      (convert-compile-time-error thunk))))))
+                      
+(define-syntax check-not-syntax-exn
+ (syntax-rules ()
+   ((_ thunk)
+    (check-not-exn (lambda () 
+                      (convert-syntax-error thunk))))))
 
 (define-syntax-rule (define-simple-check-values [header body ...] ...)
   (begin (define-simple-check header body ...) ...))

--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -30,10 +30,8 @@
          check
          check-exn
          check-compile-time-exn
-         check-syntax-exn
          check-not-exn
          check-not-compile-time-exn
-         check-not-syntax-exn
          check-true
          check-false
          check-pred
@@ -194,15 +192,6 @@
                                           (lambda ()
                                              (convert-compile-time-error body))
                                           (syntax->location #'loc)))])))
-                   
-(define-syntax (check-syntax-exn stx)
-  (with-syntax ([loc (datum->syntax #f 'loc stx)])
-     (syntax-parse stx
-       [(_ raw-pred body)
-        (syntax/loc stx (check-exn-helper raw-pred
-                                          (lambda ()
-                                             (convert-syntax-error body))
-                                          (syntax->location #'loc)))])))
 
 (define-check (check-not-exn-helper thunk location)
   (raise-error-if-not-thunk 'check-not-exn thunk)
@@ -231,14 +220,6 @@
        [(_ body)
         (syntax/loc stx (check-not-exn-helper (lambda ()
                                                  (convert-compile-time-error body))
-                                              (syntax->location #'loc)))])))
-                                              
-(define-syntax (check-not-syntax-exn stx)
-  (with-syntax ([loc (datum->syntax #f 'loc stx)])
-     (syntax-parse stx
-       [(_ body)
-        (syntax/loc stx (check-not-exn-helper (lambda ()
-                                                 (convert-syntax-error body))
                                               (syntax->location #'loc)))])))
 
 (define-syntax-rule (define-simple-check-values [header body ...] ...)

--- a/rackunit-lib/rackunit/private/test.rkt
+++ b/rackunit-lib/rackunit/private/test.rkt
@@ -79,7 +79,11 @@
          test-false
          test-not-false
          test-exn
+         test-compile-time-exn
+         test-syntax-exn
          test-not-exn
+         test-not-compile-time-exn
+         test-not-syntax-exn
 
          foldts-test-suite
          fold-test-results
@@ -97,7 +101,11 @@
 
          check
          check-exn
+         check-compile-time-exn
+         check-syntax-exn
          check-not-exn
+         check-not-compile-time-exn
+         check-not-syntax-exn
          check-true
          check-false
          check-pred
@@ -173,5 +181,17 @@
 (define-shortcut (test-exn pred thunk)
   (check-exn pred thunk))
 
+(define-shortcut (test-compile-time-exn pred thunk)
+  (check-compile-time-exn pred thunk))
+  
+(define-shortcut (test-syntax-exn pred thunk)
+  (check-syntax-exn pred thunk))
+
 (define-shortcut (test-not-exn thunk)
   (check-not-exn thunk))
+  
+(define-shortcut (test-not-compile-time-exn thunk)
+  (check-not-compile-time-exn thunk))
+  
+(define-shortcut (test-not-syntax-exn thunk)
+  (check-not-syntax-exn thunk))

--- a/rackunit-lib/rackunit/private/test.rkt
+++ b/rackunit-lib/rackunit/private/test.rkt
@@ -80,10 +80,8 @@
          test-not-false
          test-exn
          test-compile-time-exn
-         test-syntax-exn
          test-not-exn
          test-not-compile-time-exn
-         test-not-syntax-exn
 
          foldts-test-suite
          fold-test-results
@@ -102,10 +100,8 @@
          check
          check-exn
          check-compile-time-exn
-         check-syntax-exn
          check-not-exn
          check-not-compile-time-exn
-         check-not-syntax-exn
          check-true
          check-false
          check-pred
@@ -183,15 +179,9 @@
 
 (define-shortcut (test-compile-time-exn pred thunk)
   (check-compile-time-exn pred thunk))
-  
-(define-shortcut (test-syntax-exn pred thunk)
-  (check-syntax-exn pred thunk))
 
 (define-shortcut (test-not-exn thunk)
   (check-not-exn thunk))
   
 (define-shortcut (test-not-compile-time-exn thunk)
   (check-not-compile-time-exn thunk))
-  
-(define-shortcut (test-not-syntax-exn thunk)
-  (check-not-syntax-exn thunk))

--- a/rackunit-test/tests/rackunit/check-test.rkt
+++ b/rackunit-test/tests/rackunit/check-test.rkt
@@ -436,9 +436,9 @@
                (lambda ()
                  (check-not-exn (lambda (x) x)))))
                  
- ;; Verify syntax and compile time errors are now 
- ;; supported by check-compile-time-exn, check-syntax-exn,
- ;; check-not-compile-time-exn, check-not-syntax-expand
+ ;; Verify compile time exceptions are now 
+ ;; supported by check-compile-time-exn and
+ ;; check-not-compile-time-exn
  (test-case
   "check-compile-time-exn converts compile time exceptions to runtime phase"
   (check-compile-time-exn exn:fail:syntax?
@@ -446,22 +446,9 @@
                             (if (= 1 1) 1))))
 
  (test-case
-  "check-syntax-exn converts compile time syntax exceptions to runtime phase"
-  (check-syntax-exn exn:fail:syntax?
-                    (lambda ()
-                      (struct foo (fizz) #:constructor-name bar)
-                      (foo 53))))
-
- (test-case
   "check-not-compile-time-exn does not call any compile time exceptions when none are provided"
   (check-not-compile-time-exn (lambda ()
                                 (if (= 1 1) 1 1))))
-
- (test-case
-  "check-not-syntax-exn does not call any compile time exceptions when none are provided"
-  (check-not-syntax-exn (lambda ()
-                          (struct foo (fizz) #:constructor-name bar)
-                          (bar 53))))
 
   ;; Regression test
   ;; Uses of check (and derived forms) used to be un-compilable!

--- a/rackunit-test/tests/rackunit/check-test.rkt
+++ b/rackunit-test/tests/rackunit/check-test.rkt
@@ -35,7 +35,8 @@
          rackunit
          rackunit/private/check
          rackunit/private/result
-         rackunit/private/test-suite)
+         rackunit/private/test-suite
+         syntax/macro-testing)
 
 (define (make-failure-test name pred . args)
   (test-case
@@ -434,6 +435,33 @@
     (check-exn exn:fail:contract?
                (lambda ()
                  (check-not-exn (lambda (x) x)))))
+                 
+ ;; Verify syntax and compile time errors are now 
+ ;; supported by check-compile-time-exn, check-syntax-exn,
+ ;; check-not-compile-time-exn, check-not-syntax-expand
+ (test-case
+  "check-compile-time-exn converts compile time exceptions to runtime phase"
+  (check-compile-time-exn exn:fail:syntax?
+                          (lambda ()
+                            (if (= 1 1) 1))))
+
+ (test-case
+  "check-syntax-exn converts compile time syntax exceptions to runtime phase"
+  (check-syntax-exn exn:fail:syntax?
+                    (lambda ()
+                      (struct foo (fizz) #:constructor-name bar)
+                      (foo 53))))
+
+ (test-case
+  "check-not-compile-time-exn does not call any compile time exceptions when none are provided"
+  (check-not-compile-time-exn (lambda ()
+                                (if (= 1 1) 1 1))))
+
+ (test-case
+  "check-not-syntax-exn does not call any compile time exceptions when none are provided"
+  (check-not-syntax-exn (lambda ()
+                          (struct foo (fizz) #:constructor-name bar)
+                          (bar 53))))
 
   ;; Regression test
   ;; Uses of check (and derived forms) used to be un-compilable!

--- a/rackunit-typed/rackunit/main.rkt
+++ b/rackunit-typed/rackunit/main.rkt
@@ -259,7 +259,11 @@
   (test-false (check-false v))
   (test-not-false (check-not-false v))
   (test-exn (check-exn pred thunk))
-  (test-not-exn (check-not-exn thunk)))
+  (test-compile-time-exn (check-compile-time-exn pred thunk))
+  (test-syntax-exn (check-syntax-exn pred thunk))
+  (test-not-exn (check-not-exn thunk))
+  (test-not-compile-time-exn (check-not-compile-time-exn thunk))
+  (test-not-syntax-exn (check-not-syntax-exn thunk)))
 
 
 ; 3.4
@@ -310,5 +314,3 @@
                  Any))]
  [current-check-around
   (Parameter ((Thunk Any) -> Any))])
-
-

--- a/rackunit-typed/rackunit/main.rkt
+++ b/rackunit-typed/rackunit/main.rkt
@@ -260,10 +260,8 @@
   (test-not-false (check-not-false v))
   (test-exn (check-exn pred thunk))
   (test-compile-time-exn (check-compile-time-exn pred thunk))
-  (test-syntax-exn (check-syntax-exn pred thunk))
   (test-not-exn (check-not-exn thunk))
-  (test-not-compile-time-exn (check-not-compile-time-exn thunk))
-  (test-not-syntax-exn (check-not-syntax-exn thunk)))
+  (test-not-compile-time-exn (check-not-compile-time-exn thunk)))
 
 
 ; 3.4


### PR DESCRIPTION
**Resolves https://github.com/racket/racket/issues/2996**

Adds:
`check-compile-time-exn` 
`check-syntax-exn` 
`check-not-compile-time-exn` 
`check-not-syntax-exn`

As some interest was expressed in providing handy wrappers for syntax/macro-testing's `convert-compile-time-error` and `convert-syntax-error` for thunk procedures in check-exn and check-not-exn.

_Uses define-syntax instead of define-check for definition as wrappers are ignored when using define-check for expression._

Note: also adds `|| true` to the Travis yaml file to allow the build to continue running the test suite even though there seems to be an existing dependency bug in rackunit-gui before this PR. Can remove if needed.