### PR TITLE
Use the installer from Utah in .travis.yml and run the cs version too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,18 @@ cache:
 
 env:
 - PATH=~/racket/bin:$PATH
+- PATH=~/racket/bin:$PATH  VARIANT=cs
+
 
 before_install:
 - export PKG=`echo $TRAVIS_REPO_SLUG | cut -d '/' -f 2`
 - echo $PKG
-- curl -L -o installer.sh http://plt.eecs.northwestern.edu/snapshots/current/installers/min-racket-current-x86_64-linux-precise.sh
+- |
+    if [ "$VARIANT" = "cs" ]; then
+      curl --location --fail --output installer.sh http://www.cs.utah.edu/plt/snapshots/current/installers/min-racket-current-x86_64-linux-cs-xenial.sh;
+    else
+      curl --location --fail --output installer.sh http://www.cs.utah.edu/plt/snapshots/current/installers/min-racket-current-x86_64-linux-precise.sh;
+    fi
 - sh installer.sh --in-place --dest ~/racket/
 
 install:
@@ -20,10 +27,11 @@ install:
 - echo file://`pwd`/pkgs-catalog/ > catalog-config.txt
 - raco pkg config catalogs >> catalog-config.txt
 - raco pkg config --set catalogs `cat catalog-config.txt`
-- raco pkg install --auto $PKG-test
-- raco pkg install --auto $PKG-typed
-- raco pkg install --auto compiler-lib
+- raco pkg install --installation --auto $PKG-test
+- raco pkg install --installation --auto $PKG-typed
+- raco pkg install --installation --auto compiler-lib
 - ls $HOME/.racket/download-cache
+- racket -v
 
 script:
 - raco test --drdr -p $PKG-test


### PR DESCRIPTION
The installer from Northwestern are failing, so use the installer from Utah instead. I added the `--fail` option to `curl` to get a better error message in case of a problem.

Run the `cs` version too. I think it's stable enough to avoid adding it to the `allow_failure` section.

I'm using the minimal installers. The full installers are a little faster, but I think in that case I should use `raco pkg update` or something like that.

I'm not sure how related is this to https://github.com/racket/rackunit/pull/110