### PR TITLE
Update test to reflect changes in #123 and #109

### DIFF
--- a/rackunit-test/tests/rackunit/standalone-check-test.rkt
+++ b/rackunit-test/tests/rackunit/standalone-check-test.rkt
@@ -41,7 +41,7 @@
 (check = 1 1 0.0)
 
 ;; This check should display an error including the message "Outta here!"
-(check-pred (lambda (x) (error "Outta here!")) 'foo)
+(check-pred (procedure-rename (lambda (x) (error "Outta here!")) 'proc) 'foo)
 
 
 ;; This check should display a failure

--- a/rackunit-test/tests/rackunit/standalone.rkt
+++ b/rackunit-test/tests/rackunit/standalone.rkt
@@ -43,6 +43,7 @@
 ERROR
 name:       check-pred
 location:   standalone-check-test.rkt:44:0
+params:     '(#<procedure:proc> foo)
 
 Outta here!
 --------------------


### PR DESCRIPTION
Sine we "treat exceptions thrown by arguments to check as test
failures", and test failures contain "params" clause, it makes sense
for the reported message to contain the clause as well.
The clause is also useful in itself.

Use procedure-rename to avoid names
like `#<procedure:.../path/to/file.rkt:x:y>` which is brittle and
especially too sensitive to changes.