### PR TITLE
update current-check-around doc to match contract

### DIFF
--- a/rackunit-doc/rackunit/scribblings/internals.scrbl
+++ b/rackunit-doc/rackunit/scribblings/internals.scrbl
@@ -24,7 +24,7 @@ raised by check failures.  The default value is a procedure
 that will display the exception data in a user-friendly format.
 }
 
-@defparam[current-check-around check (-> (-> any) any)]{
+@defparam[current-check-around check (-> (-> void?) any)]{
 
 Parameter containing the function that handles the execution
 of checks.  The default value wraps the evaluation of
@@ -65,7 +65,7 @@ parameterized to this value within the scope of a
 structure instead of immediately evaluating the thunk.
 }
 
-@defproc[(test-suite-check-around [thunk (-> any/c)]) any/c]{
+@defproc[(test-suite-check-around [thunk (-> void?)]) any/c]{
 
 The @racket[current-check-around] parameter is parameterized
 to this value within the scope of a @racket[test-suite].


### PR DESCRIPTION
At some point, a contract was added to `current-check-around` (https://github.com/racket/rackunit/commit/1fbc98eeb7e3a6af06d7dbd32a6d6894e234297c#diff-be44254d70efbdd4192059f2a369dd9223835927001e849ed2e9628c5f63901e) but the doc was not updated.

Not 100% sure about `test-suite-check-around` but it seems to get set to `current-check-around`