### PR TITLE
revert current-check-around void? contract

### DIFF
--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -17,7 +17,7 @@
  (contract-out
   [fail-check (->* () (string?) void?)]
   [current-check-handler (parameter/c (-> any/c any))]
-  [current-check-around (parameter/c (-> (-> void?) any))]
+  [current-check-around (parameter/c (-> (-> any/c) any))]
   [plain-check-around (-> (-> void?) void?)]))
 
 (provide check-around


### PR DESCRIPTION
I would like to discuss reverting part of https://github.com/racket/rackunit/commit/1fbc98eeb7e3a6af06d7dbd32a6d6894e234297c

There doesn't seem to be a reason to limit the behavior, it's different from what the docs specify, and it breaks existing programs.