### PR TITLE
improve source locations in stacktraces

### DIFF
--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -113,15 +113,16 @@
       (with-syntax ([loc (datum->syntax #f 'loc stx)])
         (syntax-parse stx
           [(chk . args)
-           #'(let ([location (syntax->location #'loc)])
+           #`(let ([location (syntax->location #'loc)])
                (with-default-check-info*
                 (list (make-check-name 'name)
                       (make-check-location location)
                       (make-check-expression '(chk . args)))
-                (λ ()
-                  ((check-impl #:location location
-                               #:expression '(chk . args))
-                   . args))))]
+                #,(syntax/loc #'loc
+                    (λ ()
+                      ((check-impl #:location location
+                                   #:expression '(chk . args))
+                       . args)))))]
           [chk:id
            #'(check-impl #:location (syntax->location #'loc)
                          #:expression 'chk)])))))


### PR DESCRIPTION
When there is an exception while running `check-equal?`, eg with this program:

```
#lang racket
(require rackunit)

(define (f x) (car x))
(set! f f)

(check-equal? 1 (f #f))
```

then this PR improves the error reporting so we see the source location of the `check-equal?` in the stack. Before this pull request, we'd see something like this:

```
car: contract violation
  expected: pair?
  given: #f
  context...:
   /Users/robby/git/exp/plt/racket/share/pkgs/rackunit-lib/rackunit/private/check.rkt:121:16
   body of "/Users/robby/tmp.rkt"
```

and after it, the line that points to `rackunit/private/check.rkt:121:16` points to the place where the `check-equal?` itself appears, `/Users/robby/tmp.rkt:7:0` in this case.