### PR TITLE
typed: Remove extra call to `current-test-case-around`

### DIFF
--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -21,7 +21,7 @@
   [plain-check-around (-> (-> void?) void?)]))
 
 (provide check-around
-         
+
          define-check
          define-binary-check
          define-simple-check
@@ -104,7 +104,7 @@
           (with-default-check-info* infos
             (λ () ((current-check-around) (λ () body ... (void))))))
       'pub)))
-                                      
+
 
 (define-simple-macro (define-check (name:id formal:id ...) body:expr ...)
   (begin

--- a/rackunit-typed/rackunit/main.rkt
+++ b/rackunit-typed/rackunit/main.rkt
@@ -97,17 +97,15 @@
   (syntax-case stx ()
     [(_ expr ...)
      (syntax/loc stx
-       ((current-test-case-around)
-        (lambda ()
-          (with-handlers ([(λ (e)
-                             (and (exn:fail? e)
-                                  (not (exn:test? e))))
-                           (λ ([e : exn:fail])
-                             (test-log! #f)
-                             (raise e))])
-          (parameterize ([current-check-handler raise])
-            (void)
-            expr ...)))))]
+       (with-handlers ([(λ (e)
+                          (and (exn:fail? e)
+                               (not (exn:test? e))))
+                        (λ ([e : exn:fail])
+                          (test-log! #f)
+                          (raise e))])
+         (parameterize ([current-check-handler raise])
+           (void)
+           expr ...)))]
     [_
      (raise-syntax-error
       #f
@@ -310,5 +308,3 @@
                  Any))]
  [current-check-around
   (Parameter ((Thunk Any) -> Any))])
-
-


### PR DESCRIPTION
It's not necessary to wrap a test case in `current-test-case-around`; that will be done later. Doing so increments the running test count (and, possibly, the running test failure count) twice.

The proposed change may seem implausible on its face. I also feel somewhat less than confident that this is the right thing to do. But I can confirm that this does the job.

closes #132