### PR TITLE
Improve formatting for short-but-multiline check-info strings

### DIFF
--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -76,13 +76,17 @@
          (define one-line-candidate
            (parameterize ([pretty-print-columns 'infinity])
              (format "~a:~a  ~a" name pad (info-value->string value))))
-         (if (<= (string-length one-line-candidate) (pretty-print-columns))
+         (if (short-line? one-line-candidate)
              one-line-candidate
              (format "~a:\n~a"
                      name
                      (string-indent
                       (info-value->string value)
                       multi-line-indent-amount)))]))
+
+(define (short-line? line)
+  (and (<= (string-length line) (pretty-print-columns))
+       (not (string-contains? line "\n"))))
 
 (define (nested-info->string nested verbose? name-width)
   (define infos (nested-info-values nested))


### PR DESCRIPTION
The current logic doesn't consider cases where the string contains only a few characters, but some of those characters are newlines.