### PR TITLE
Support images in check failure output

### DIFF
--- a/rackunit-lib/rackunit/private/check-info.rkt
+++ b/rackunit-lib/rackunit/private/check-info.rkt
@@ -19,7 +19,7 @@
   [struct nested-info ([values (listof check-info?)])]
   [struct verbose-info ([value any/c])]
   [struct dynamic-info ([proc (-> any/c)])]
-  [info-value->string (-> any/c string?)]
+  [print-info-value (-> any/c any)]
   [current-check-info (parameter/c (listof check-info?))]
   [check-info-contains-key? (check-info-> symbol? boolean?)]
   [check-info-ref (check-info-> symbol? (or/c check-info? #f))]
@@ -46,16 +46,17 @@
 (struct nested-info (values) #:transparent)
 (struct dynamic-info (proc) #:transparent)
 
-(define (info-value->string info-value)
+(define (print-info-value info-value)
   (cond
-    [(string-info? info-value) (string-info-value info-value)]
+    [(string-info? info-value) (display (string-info-value info-value))]
     [(location-info? info-value)
-     (trim-current-directory
-      (location->string (location-info-value info-value)))]
-    [(pretty-info? info-value) (pretty-format (pretty-info-value info-value))]
+     (display (trim-current-directory
+                (location->string (location-info-value info-value))))]
+    [(pretty-info? info-value) (pretty-write (pretty-info-value info-value))]
     [(verbose-info? info-value)
-     (info-value->string (verbose-info-value info-value))]
-    [else (~s info-value)]))
+     (print-info-value (verbose-info-value info-value))]
+    [else
+     (write info-value)]))
 
 (define (trim-current-directory path)
   (define cd (path->string (current-directory)))

--- a/rackunit-lib/rackunit/private/check-info.rkt
+++ b/rackunit-lib/rackunit/private/check-info.rkt
@@ -52,7 +52,8 @@
     [(location-info? info-value)
      (display (trim-current-directory
                 (location->string (location-info-value info-value))))]
-    [(pretty-info? info-value) (pretty-write (pretty-info-value info-value))]
+    [(pretty-info? info-value)
+     (pretty-write (pretty-info-value info-value) #:newline? #f)]
     [(verbose-info? info-value)
      (print-info-value (verbose-info-value info-value))]
     [else

--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -54,7 +54,9 @@
                                 #:name-width [name-width* minimum-name-width])
   (define stack (if verbose? stack* (simplify-params stack*)))
   (define name-width (max name-width* (check-info-stack-name-width stack)))
-  (define (print-info info) (print-check-info info verbose? name-width))
+  (define (print-info info)
+    (print-check-info info verbose? name-width)
+    (newline))
   (for-each print-info stack))
 
 (define (print-check-info info verbose? name-width)
@@ -77,11 +79,10 @@
                (parameterize ([pretty-print-columns 'infinity])
                  (print-name name name-width)
                  (print-info-value value)))))
-
          (cond
            [(short-line? one-line-candidate)
-            (display one-line-candidate)
-            (newline)]
+            (print-name name name-width)
+            (print-info-value value)]
            [else
             (print-name name)
             (newline)

--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -54,9 +54,7 @@
                                 #:name-width [name-width* minimum-name-width])
   (define stack (if verbose? stack* (simplify-params stack*)))
   (define name-width (max name-width* (check-info-stack-name-width stack)))
-  (define (print-info info)
-    (print-check-info info verbose? name-width)
-    (newline))
+  (define (print-info info) (print-check-info info verbose? name-width))
   (for-each print-info stack))
 
 (define (print-check-info info verbose? name-width)
@@ -82,7 +80,8 @@
          (cond
            [(short-line? one-line-candidate)
             (print-name name name-width)
-            (print-info-value value)]
+            (print-info-value value)
+            (newline)]
            [else
             (print-name name)
             (newline)

--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -1,8 +1,8 @@
 #lang racket/base
 (require racket/list
-         racket/match
-         racket/string
+         racket/port
          racket/pretty
+         racket/string
          "base.rkt"
          "check-info.rkt")
 
@@ -18,6 +18,7 @@
 (define minimum-name-width 9)
 
 (define nested-indent-amount 2)
+(define nesting-level (make-parameter 0))
 (define multi-line-indent-amount 2)
 
 (define (display-test-result res
@@ -40,10 +41,6 @@
 (define (string-padding str desired-len)
   (make-string (max (- desired-len (string-length str)) 0) #\space))
 
-(define (string-indent str amnt)
-  (define pad (make-string amnt #\space))
-  (string-append pad (string-replace str "\n" (string-append "\n" pad))))
-
 (define (check-info-name-width check-info)
   (string-length
    (symbol->string
@@ -53,50 +50,60 @@
   (define widths (map check-info-name-width check-info-stack))
   (apply max 0 widths))
 
-(define (check-info-stack->string stack* verbose?
-                                  #:name-width [name-width* minimum-name-width])
+(define (print-check-info-stack stack* verbose?
+                                #:name-width [name-width* minimum-name-width])
   (define stack (if verbose? stack* (simplify-params stack*)))
   (define name-width (max name-width* (check-info-stack-name-width stack)))
-  (define (info->str info) (check-info->string info verbose? name-width))
-  (string-join (map info->str stack) "\n"))
+  (define (print-info info) (print-check-info info verbose? name-width))
+  (for-each print-info stack))
 
-(define (check-info->string info verbose? name-width)
+(define (print-check-info info verbose? name-width)
   (define name (symbol->string (check-info-name info)))
   (define value (check-info-value info))
   (cond [(dynamic-info? value)
          (define new-info
            (make-check-info (check-info-name info)
                             ((dynamic-info-proc value))))
-         (check-info->string new-info verbose? name-width)]
+         (print-check-info new-info verbose? name-width)]
         [(nested-info? value)
-         (define nested-str (nested-info->string value verbose? name-width))
-         (format "~a:\n~a" name nested-str)]
+         (print-name name)
+         (newline)
+         (parameterize ([nesting-level (add1 (nesting-level))])
+           (print-check-info-stack (nested-info-values value) verbose? #:name-width name-width))]
         [else
-         (define pad (string-padding name name-width))
          (define one-line-candidate
-           (parameterize ([pretty-print-columns 'infinity])
-             (format "~a:~a  ~a" name pad (info-value->string value))))
-         (if (short-line? one-line-candidate)
-             one-line-candidate
-             (format "~a:\n~a"
-                     name
-                     (string-indent
-                      (info-value->string value)
-                      multi-line-indent-amount)))]))
+           (with-output-to-string
+             (lambda ()
+               (parameterize ([pretty-print-columns 'infinity])
+                 (print-name name name-width)
+                 (print-info-value value)))))
+
+         (cond
+           [(short-line? one-line-candidate)
+            (display one-line-candidate)
+            (newline)]
+           [else
+            (print-name name)
+            (newline)
+            (display (make-string multi-line-indent-amount #\space))
+            (print-info-value value)
+            (newline)])]))
+
+(define (print-name name [name-width #f])
+  (define indent (make-string (* nested-indent-amount (nesting-level)) #\space))
+  (define pad
+    (cond
+    [name-width (string-append "  " (string-padding name name-width))]
+    [else ""]))
+  (printf "~a~a:~a" indent name pad))
 
 (define (short-line? line)
   (and (<= (string-length line) (pretty-print-columns))
        (not (string-contains? line "\n"))))
 
-(define (nested-info->string nested verbose? name-width)
-  (define infos (nested-info-values nested))
-  (define nested-str
-    (check-info-stack->string infos verbose? #:name-width name-width))
-  (string-indent nested-str nested-indent-amount))
-
 ;; display-check-info-stack : (listof check-info) -> void
 (define (display-check-info-stack stack #:verbose? [verbose? #f])
-  (displayln (check-info-stack->string stack verbose?)))
+  (print-check-info-stack stack verbose?))
 
 ;; display-test-name : (U string #f) -> void
 (define (display-test-name name)

--- a/rackunit-test/tests/rackunit/format-test.rkt
+++ b/rackunit-test/tests/rackunit/format-test.rkt
@@ -2,9 +2,10 @@
 
 (require racket/function
          racket/port
+         racket/list
+         racket/pretty
          rackunit
          rackunit/private/check-info
-         rackunit/private/format
          (submod rackunit/private/format for-test))
 
 (define-check (check-output expected thnk)
@@ -16,11 +17,12 @@
        (fail-check)))))
 
 (test-case "display-check-info-stack"
-  (check-output "name:       \"foo\"\nactual:     1\nexpected:   2\n"
-                (thunk (display-check-info-stack
-                        (list (make-check-name "foo")
-                              (make-check-actual 1)
-                              (make-check-expected 2)))))
+  (test-case "basic"
+    (check-output "name:       \"foo\"\nactual:     1\nexpected:   2\n"
+                  (thunk (display-check-info-stack
+                           (list (make-check-name "foo")
+                                 (make-check-actual 1)
+                                 (make-check-expected 2))))))
   (test-case "string-info"
     (check-output "name:       foo\n"
                   (thunk (display-check-info-stack
@@ -47,4 +49,10 @@
                               (thunk
                                (nested-info
                                 (list (make-check-info 'foo 1)
-                                      (make-check-info 'bar 2)))))))))))))
+                                      (make-check-info 'bar 2))))))))))))
+  (let ([big (make-list 30 99)])
+    (test-case "multi-line"
+      (check-output (format "foo:\n  ~s\n" big)
+                    (thunk
+                     (display-check-info-stack
+                      (list (make-check-info 'foo big))))))))


### PR DESCRIPTION
Fixes #130

This PR makes `rackunit` print values directly, as opposed to turning them into strings first.