### PR TITLE
Fix some failures discovered in PR #138 discussion

### DIFF
--- a/rackunit-test/tests/rackunit/check-info-test.rkt
+++ b/rackunit-test/tests/rackunit/check-info-test.rkt
@@ -28,6 +28,7 @@
 #lang racket/base
 
 (require racket/function
+         racket/list
          rackunit
          rackunit/private/check-info
          syntax/srcloc
@@ -114,8 +115,15 @@
         (with-check-info (['custom 'custom]) (old-around chk)))
       (parameterize ([current-check-around new-around])
         (check-foo 'arg1 'arg2 'arg3)))
-    (check-equal? (call/info-box call-check-foo/extra-infos)
-                  (list 'name 'location 'expression 'params 'custom)))
+    (define info-keys (call/info-box call-check-foo/extra-infos))
+    (check-true (< (index-of info-keys 'name)
+                   (index-of info-keys 'location)
+                   (index-of info-keys 'expression)
+                   (index-of info-keys 'custom)))
+    (check-true (< (index-of info-keys 'name)
+                   (index-of info-keys 'location)
+                   (index-of info-keys 'expression)
+                   (index-of info-keys 'params))))
 
   (test-case "check-info-ref / check-info-contains-key"
     (define info0 (list (make-check-name 'my-name)))


### PR DESCRIPTION
When an `exn` is raised, use the check-info stack at the point the exception was raised, not the one at the point `(current-check-around)` was called.

This fixes the `standalone.rkt` failure about the presence of the `params` check-info if an error happens within the body of a check.

It doesn't really fix the `define-check infos are added before calling current-check-around` failure in `check-info-test.rkt` about the order of the `params` check-info relative to a custom check-info added by a user-defined `current-check-around`, instead it modifies the test to be less strict about the check-info/check-around order.

notjack:
> short answer: there needs to be a way for the code throwing the exception to communicate the check info stack *at the time the exception is created* to the `current-check-around` handler. If it’s a regular check failure created with `fail-check`, then `fail-check` will capture the current info stack and throw an instance of `exn:test:check` with the current continuation marks and the current info stack. But if it’s any *other* kind of exception, like a run-of-the-mill contract error, the info stack isn’t a field of the exception…. but the current info stack is a parameter, and parameters are stored in the continuation marks anyway, so it should be possible to get the `current-check-info` parameter’s value directly from the mark set.