### PR TITLE
rackunit-typed: fix exn:test type declaration

### DIFF
--- a/rackunit-lib/rackunit/private/base.rkt
+++ b/rackunit-lib/rackunit/private/base.rkt
@@ -10,7 +10,7 @@
 ;; struct (rackunit-test-suite test) : string (fdown fup fhere seed -> (listof test-result)) thunk thunk
 (define-struct (rackunit-test-suite test) (name tests before after) #:transparent)
 
-;; struct exn:test exn : ()
+;; struct exn:test exn:fail : ()
 ;;
 ;; The exception throw by test failures
 (define-struct (exn:test exn:fail) ())

--- a/rackunit-typed/rackunit/main.rkt
+++ b/rackunit-typed/rackunit/main.rkt
@@ -99,9 +99,11 @@
      (syntax/loc stx
        ((current-test-case-around)
         (lambda ()
-          (with-handlers ([(λ (e)
-                             (and (exn:fail? e)
-                                  (not (exn:test? e))))
+          (with-handlers ([(ann
+                             (λ (e)
+                               (and (exn:fail? e)
+                                    (not (exn:test? e))))
+                             (-> Any Boolean : #:+ exn:fail))
                            (λ ([e : exn:fail])
                              (test-log! #f)
                              (raise e))])
@@ -270,7 +272,7 @@
 ; XXX require/expose seems WRONG for typed/racket
 
 ; 3.7
-(require-typed-struct (exn:test exn) () rackunit)
+(require-typed-struct (exn:test exn:fail) () rackunit)
 (require-typed-struct (exn:test:check exn:test) ([stack : (Listof CheckInfo)]) rackunit)
 (require-typed-struct test-result ([test-case-name : (Option String)]) rackunit)
 (require-typed-struct (test-failure test-result) ([result : Any]) rackunit)


### PR DESCRIPTION
Change the annotation because `exn:test` is really an `exn:fail` (and not a direct sub-struct of `exn`).

The old annotation had a funny consequence for the type of `test-begin`. It has a predicate that checks for `exn:fail` structs that are not `exn:fail:test` structs. Here's the old code:

```
          (with-handlers ([(λ (e)
                             (and (exn:fail? e)
                                  (not (exn:test? e))))
```

The funny consequence is that `(exn:test? e)` has type `False` because the typechecker thinks that `exn:fail` is distinct. And so, the whole old predicate boils down to `exn:fail?`.

With the new annotation, the predicate has an asymmetric occurrence type. That's why I had to add an `ann` there.

