### PR TITLE
Fix incorrect usage of optional message in rackunit-test

### DIFF
--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -112,14 +112,16 @@
                 #:check-around [check-around current-check-around])
     (procedure-rename
       (λ (formal ... [message #f])
-          (define infos
-            (list/if (make-check-name 'pub)
-                     (make-check-location location)
-                     (make-check-expression expression)
-                     (make-check-params (list formal ...))
-                     (and message (make-check-message message))))
-          (with-default-check-info* infos
-            (λ () ((check-around) (λ () body ... (void))))))
+        (when (and message (not (string? message)))
+          (raise-argument-error 'pub "(or/c #f string?)" message))
+        (define infos
+          (list/if (make-check-name 'pub)
+                   (make-check-location location)
+                   (make-check-expression expression)
+                   (make-check-params (list formal ...))
+                   (and message (make-check-message message))))
+        (with-default-check-info* infos
+          (λ () ((check-around) (λ () body ... (void))))))
       'pub)))
 
 (define-simple-macro (define-check (name:check-name formal:id ...) body:expr ...)

--- a/rackunit-test/tests/rackunit/check-test.rkt
+++ b/rackunit-test/tests/rackunit/check-test.rkt
@@ -478,4 +478,8 @@
                  (parameterize ([current-check-handler (lambda (e) (escape 'foo))]
                                 [current-check-around check-around])
                    (check-eq? 'a 'b)))
-               'foo)))
+               'foo))
+
+  (test-case "Optional message is handled correctly"
+    (check-exn (regexp (regexp-quote "expected: (or/c #f string?)"))
+               (lambda () (check = 1 2 0.0)))))

--- a/rackunit-test/tests/rackunit/standalone-check-higher-order-test.rkt
+++ b/rackunit-test/tests/rackunit/standalone-check-higher-order-test.rkt
@@ -40,21 +40,21 @@
 (define my-check check)
 
 ;; This check should succeed
-(my-check = 1 1 0.0)
+(my-check = 1 1)
 
 ;; This check should display an error including the message "Outta here!"
 ((values check-pred) (procedure-rename (lambda (x) (error "Outta here!")) 'proc) 'foo)
 
 
 ;; This check should display a failure
-(my-check = 1 2 0.0)
+(my-check = 1 2)
 
 ;; This check should display "Oh HAI!"
 (parameterize
     ([current-check-handler (lambda (e) (display "Oh HAI!\n"))])
-  (my-check = 1 2 0.0))
+  (my-check = 1 2))
 
 ;; This check should display "I didn't run"
 (parameterize
     ([current-check-around (lambda (t) (display "I didn't run\n"))])
-  (my-check = 1 1 0.0))
+  (my-check = 1 1))

--- a/rackunit-test/tests/rackunit/standalone-check-test.rkt
+++ b/rackunit-test/tests/rackunit/standalone-check-test.rkt
@@ -38,21 +38,21 @@
   (displayln "run as program for tests"))
 
 ;; This check should succeed
-(check = 1 1 0.0)
+(check = 1 1)
 
 ;; This check should display an error including the message "Outta here!"
 (check-pred (procedure-rename (lambda (x) (error "Outta here!")) 'proc) 'foo)
 
 
 ;; This check should display a failure
-(check = 1 2 0.0)
+(check = 1 2)
 
 ;; This check should display "Oh HAI!"
 (parameterize
     ([current-check-handler (lambda (e) (display "Oh HAI!\n"))])
-  (check = 1 2 0.0))
+  (check = 1 2))
 
 ;; This check should display "I didn't run"
 (parameterize
     ([current-check-around (lambda (t) (display "I didn't run\n"))])
-  (check = 1 1 0.0))
+  (check = 1 1))

--- a/rackunit-test/tests/rackunit/standalone.rkt
+++ b/rackunit-test/tests/rackunit/standalone.rkt
@@ -52,7 +52,6 @@ FAILURE
 name:       check
 location:   standalone-check-test.rkt:48:0
 params:     '(#<procedure:=> 1 2)
-message:    0.0
 --------------------
 ")
 
@@ -72,7 +71,6 @@ FAILURE
 name:       check
 location:   standalone-check-higher-order-test.rkt:40:17
 params:     '(#<procedure:=> 1 2)
-message:    0.0
 --------------------
 ")
 


### PR DESCRIPTION
The tests either meant to use `check =` without an epsilon, or
`check-=` with an epsilon. Currently, it uses `check =` with an epsilon,
so the epsilon becomes a message. This PR fixes the tests.

Furthermore, there should be a guard to check that the optional message
argument is indeed either `#f` or `string?`. This PR also does that.