### PR TITLE
Improve check-match failure message

### DIFF
--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -271,7 +271,9 @@
                 (syntax->location (quote-syntax #,(datum->syntax #f 'loc stx))))
               (make-check-expression '#,(syntax->datum stx))
               (make-check-actual actual-val)
-              (make-check-expected 'expected))
+              (make-check-info 'pattern 'expected)
+              #,@(cond [(eq? (syntax-e #'pred) #t) '()]
+                       [else #'((make-check-info 'condition 'pred))]))
         (lambda ()
          (check-true (match actual-val
                        [expected pred]

--- a/rackunit-test/tests/rackunit/check-test.rkt
+++ b/rackunit-test/tests/rackunit/check-test.rkt
@@ -36,6 +36,7 @@
          rackunit/private/check
          rackunit/private/result
          rackunit/private/test-suite
+         (only-in rackunit/log test-log-enabled?)
          (only-in rackunit/text-ui run-tests)
          (only-in rackunit/private/check-info current-check-info))
 
@@ -146,7 +147,9 @@
       (define actual
         (call-with-output-string
          (lambda (e)
-           (parameterize ([current-error-port e] [current-check-info '()])
+           (parameterize ([current-error-port e]
+                          [current-check-info '()]
+                          [test-log-enabled? #false])
              (run-tests (test-suite "check-failure-message" (thunk)))))))
       (with-check-info*
        (list (make-check-info 'actual (string-info actual)))

--- a/rackunit-test/tests/rackunit/check-test.rkt
+++ b/rackunit-test/tests/rackunit/check-test.rkt
@@ -35,7 +35,9 @@
          rackunit
          rackunit/private/check
          rackunit/private/result
-         rackunit/private/test-suite)
+         rackunit/private/test-suite
+         (only-in rackunit/text-ui run-tests)
+         (only-in rackunit/private/check-info current-check-info))
 
 (define (make-failure-test name pred . args)
   (test-case
@@ -138,7 +140,43 @@
       (check-match (data 1 2 (data 1 2 3))
                    (data _ _ (data x y z))
                    (equal? (+ x y z) 6))))
-   
+
+  (test-case "check-match failure message"
+    (define-check (check-failure-message rx thunk)
+      (define actual
+        (call-with-output-string
+         (lambda (e)
+           (parameterize ([current-error-port e] [current-check-info '()])
+             (run-tests (test-suite "check-failure-message" (thunk)))))))
+      (with-check-info*
+       (list (make-check-info 'actual (string-info actual)))
+       (lambda () (check-regexp-match rx actual))))
+    (define (rx . strs) (regexp (apply string-append strs)))
+    (check-failure-message
+     (rx
+      "name: *check-match\n.*"
+      "actual: *1\n"
+      "pattern: *a\n"
+      "condition: *" (regexp-quote "(symbol? a)"))
+     (lambda ()
+       (check-match 1 a (symbol? a))))
+    (check-failure-message
+     (rx
+      "name: *check-match\n.*"
+      "actual: *" (regexp-quote "'(1)") "\n"
+      "pattern: *" (regexp-quote "(quasiquote ((unquote a)))") "\n"
+      "condition: *" (regexp-quote "(symbol? a)"))
+     (lambda ()
+       (check-match `(1) `(,a) (symbol? a))))
+    (check-failure-message
+     (rx
+      "name: *check-match\n.*"
+      "actual: *" (regexp-quote "'a") "\n"
+      "pattern: *" (regexp-quote "a") "\n"
+      "condition: *" (regexp-quote "(integer? a)"))
+     (lambda ()
+       (check-match 'a a (integer? a)))))
+
   ;; Failures
   (make-failure-test "check-equal? failure"
                      check-equal? 1 2)


### PR DESCRIPTION
Fixes #163 by changing the `expected` check-info in `pretty-print` mode into a `pattern` check-info in `write` mode, and adding a `condition` check-info in `write` mode when there's a condition that must pass too.

The new messages look like this:
```
--------------------
. FAILURE
name:       check-match
location:   meow.rkt:5:0
actual:     1
pattern:    a
condition:  (symbol? a)
--------------------
--------------------
. FAILURE
name:       check-match
location:   meow.rkt:10:0
actual:     '(1)
pattern:    `(,a)
condition:  (symbol? a)
--------------------
--------------------
. FAILURE
name:       check-match
location:   meow.rkt:15:0
actual:     'a
pattern:    a
condition:  (integer? a)
--------------------
```