### PR TITLE
Improved cheeck-= and check-within error messages

### DIFF
--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -106,7 +106,7 @@ like lists, flvectors and hash tables.
 For example, the following checks pass:
 
 @interaction[#:eval rackunit-eval
-  (check-within (list 6.02 9.99) (list 6 10) 0.05)
+  (check-within (list 6 10) (list 6.02 9.99) 0.05)
   (check-within (flvector 3.01 4.01 5.014) (flvector 3.0 4.0 5.0) 0.02)
   (check-within (hash 'C 25 'F 77) (hash 'C 20 'F 68) 10)
 ]

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -113,7 +113,12 @@ For example, the following checks pass:
 
 And the following checks fail:
 @interaction[#:eval rackunit-eval
-  (check-within (list 6.02e23 9.8) (list 6.0e23 10.0) 0.05)
+  (define (avogadro-constant) 6.0e23) ;computes the Avogadro constant
+  (define (gravity-constant)  10.0)   ;computes the Gravity constant
+  
+  (check-within (list (avogadro-constant) (gravity-constant))
+                (list 6,02214076e23 9.81) 0.05)
+  
   (check-within (hash 'C 18 'F 64) (hash 'C 25 'F 77) 10)
 ]
 

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -152,6 +152,11 @@ For example, the following checks succeed:
      (raise (make-exn:fail "Hi there"
                            (current-continuation-marks)))))
   (check-exn
+   #rx"[Hh]i there"
+   (lambda ()
+     (raise (make-exn:fail "Hi there"
+                           (current-continuation-marks)))))
+  (check-exn
    exn:fail?
    (lambda ()
      (error 'hi "there")))
@@ -163,6 +168,11 @@ The following check fails:
   (check-exn exn:fail?
              (lambda ()
                (break-thread (current-thread))))
+  (check-exn
+   #rx"Hello there"
+   (lambda ()
+     (raise (make-exn:fail "Hi there"
+                           (current-continuation-marks)))))
 ]
 
 The following example is a common mistake. The call to @racket[error]

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -114,10 +114,10 @@ For example, the following checks pass:
 And the following checks fail:
 @interaction[#:eval rackunit-eval
   (define (avogadro-constant) 6.0e23) ;computes the Avogadro constant
-  (define (gravity-constant)  10.0)   ;computes the Gravity constant
+  (define (gravitational-acc)  10.0)  ;computes the gravitational acceleration
   
-  (check-within (list (avogadro-constant) (gravity-constant))
-                (list 6.02214076e23 9.81) 0.05)
+  (check-within (list (avogadro-constant) (gravitational-acc))
+                (list 6.02214076e23 9.80665) 0.05)
   
   (check-within (hash 'C 18 'F 64) (hash 'C 25 'F 77) 10)
 ]

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -117,7 +117,7 @@ And the following checks fail:
   (define (gravity-constant)  10.0)   ;computes the Gravity constant
   
   (check-within (list (avogadro-constant) (gravity-constant))
-                (list 6,02214076e23 9.81) 0.05)
+                (list 6.02214076e23 9.81) 0.05)
   
   (check-within (hash 'C 18 'F 64) (hash 'C 25 'F 77) 10)
 ]

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -74,40 +74,46 @@ The following check fails:
          void?]{
 
 Checks that @racket[v1] and @racket[v2] are numbers within
-@racket[epsilon] of one another.  The optional
-@racket[message] is included in the output if the check
-fails.
+@racket[epsilon] of one another. Usually the first number
+is produced by a function, the second number is the expected
+value and epsilon is the tolerance. The optional @racket[message]
+is included in the output if the check fails.
 
 For example, the following check passes:
 
 @interaction[#:eval rackunit-eval
-  (check-= 1.0 1.01 0.02 "I work")
+  (define (golden-ratio) 1.62) ;computes the golden ratio
+  (check-= (golden-ratio) 1.618033988749  0.01 "I work")
 ]
+
 The following check fails:
 @interaction[#:eval rackunit-eval
-  (check-= 1.0 1.01 0.005 "I fail")
+  (check-= (golden-ratio) 1.618033988749  0.001 "I fail")
 ]
 }
 
 @defproc[(check-within [v1 any/c] [v2 any/c] [epsilon number?] [message (or/c string? #f) #f])
          void?]{
-
+                
 Checks that @racket[v1] and @racket[v2] are @racket[equal?] to each
 other, while allowing numbers @italic{inside} of them to be different by
 at most @racket[epsilon] from one another. If @racket[(equal? v1 v2)] would
 call @racket[equal?] on sub-pieces that are numbers, then those numbers are
 considered "good enough" if they're within @racket[epsilon].
+This check is similar to @racket[check-=] except it works on data structures
+like lists, flvectors and hash tables.
 
 For example, the following checks pass:
 
 @interaction[#:eval rackunit-eval
-  (check-within (list 6 10) (list 6.02 9.99) 0.05)
-  (check-within (flvector 3.0 4.0 5.0) (flvector 3.01 4.01 5.014) 0.02)
-  (check-within (hash 'C 20 'F 68) (hash 'C 25 'F 77) 10)
+  (check-within (list 6.02 9.99) (list 6 10) 0.05)
+  (check-within (flvector 3.01 4.01 5.014) (flvector 3.0 4.0 5.0) 0.02)
+  (check-within (hash 'C 25 'F 77) (hash 'C 20 'F 68) 10)
 ]
+
 And the following checks fail:
 @interaction[#:eval rackunit-eval
-  (check-within (list 6.0e23 10.0) (list 6.02e23 9.8) 0.05)
+  (check-within (list 6.02e23 9.8) (list 6.0e23 10.0) 0.05)
   (check-within (hash 'C 18 'F 64) (hash 'C 25 'F 77) 10)
 ]
 

--- a/rackunit-lib/rackunit/private/check-info.rkt
+++ b/rackunit-lib/rackunit/private/check-info.rkt
@@ -124,6 +124,7 @@
 (define-check-type message any/c)
 (define-check-type actual any/c #:wrapper pretty-info)
 (define-check-type expected any/c #:wrapper pretty-info)
+(define-check-type tolerance any/c #:wrapper pretty-info)
 
 (define check-info-ref
   (case-lambda

--- a/rackunit-lib/rackunit/private/check.rkt
+++ b/rackunit-lib/rackunit/private/check.rkt
@@ -228,8 +228,6 @@
 (define-simple-check-values
   [(check operator expr1 expr2) (operator expr1 expr2)]
   [(check-pred predicate expr) (predicate expr)]
-  [(check-= expr1 expr2 epsilon)
-   (<= (magnitude (- expr1 expr2)) epsilon)]
   [(check-true expr) (eq? expr #t)]
   [(check-false expr) (eq? expr #f)]
   [(check-not-false expr) expr]
@@ -238,10 +236,20 @@
   [(check-not-equal? expr1 expr2) (not (equal? expr1 expr2))]
   [(fail) #f])
 
+(define-check (check-= expr1 expr2 epsilon)
+  (with-check-info*
+   (list (make-check-actual expr1)
+         (make-check-expected expr2)
+         (make-check-tolerance epsilon))
+   (lambda ()
+     (unless (<= (magnitude (- expr1 expr2)) epsilon)
+       (fail-check)))))
+
 (define-check (check-within expr1 expr2 epsilon)
   (with-check-info*
    (list (make-check-actual expr1)
-         (make-check-expected expr2))
+         (make-check-expected expr2)
+         (make-check-tolerance epsilon))
    (lambda ()
      (unless (equal?/within expr1 expr2 epsilon)
        (fail-check)))))


### PR DESCRIPTION
Improved documentation and error messages of `check-=` and `check-within` as discussed in issue #165.