### PR TITLE
Fix hierarchy in reported test failure

### DIFF
--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -44,7 +44,9 @@
 (define (combine-names test-name suite-names)
   (define any-names? (or test-name (not (empty? suite-names))))
   (and any-names?
-       (string-join (snoc (or test-name "Unnamed test") suite-names) " > ")))
+       (string-join (snoc (or test-name "Unnamed test")
+                          (reverse suite-names))
+                    " > ")))
 
 (define (snoc v vs) (append vs (list v)))
 

--- a/rackunit-lib/rackunit/private/format.rkt
+++ b/rackunit-lib/rackunit/private/format.rkt
@@ -44,11 +44,9 @@
 (define (combine-names test-name suite-names)
   (define any-names? (or test-name (not (empty? suite-names))))
   (and any-names?
-       (string-join (snoc (or test-name "Unnamed test")
-                          (reverse suite-names))
+       (string-join (reverse (cons (or test-name "Unnamed test")
+                                   suite-names))
                     " > ")))
-
-(define (snoc v vs) (append vs (list v)))
 
 (define (string-padding str desired-len)
   (make-string (max (- desired-len (string-length str)) 0) #\space))

--- a/rackunit-test/tests/rackunit/nested-test-suite.rkt
+++ b/rackunit-test/tests/rackunit/nested-test-suite.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+
+(module core racket/base
+  (require rackunit
+           rackunit/text-ui)
+  (run-tests (test-suite "tests"
+               (test-suite "sub-tests"
+                 (check-equal? 1 2)))))
+
+(module test racket/base
+  (require syntax/location
+           racket/port
+           rackunit)
+  ;; Use a separate namespace to avoid logging results
+  ;; in this namespace (where `raco test` would see errors).
+  (define output
+    (with-output-to-string
+      (lambda ()
+        (parameterize ([current-error-port (current-output-port)]
+                       [current-namespace (make-base-namespace)])
+          (dynamic-require (quote-module-path ".." core) #f)))))
+  (check-regexp-match
+   (regexp (regexp-quote "--------------------\ntests > sub-tests > Unnamed test\nFAILURE"))
+   output))


### PR DESCRIPTION
Fix #170 

Before:
```
$ make test-flow
racket -y qi-test/tests/flow.rkt
--------------------
crossover > routing forms > flow tests > a test that should fail
FAILURE
name:       check-equal?
location:   qi-test/tests/flow.rkt:528:5
actual:     "ba"
expected:   #f
--------------------
```

After:
```
$ make test-flow
racket -y qi-test/tests/flow.rkt
--------------------
flow tests > routing forms > crossover > a test that should fail
FAILURE
name:       check-equal?
location:   qi-test/tests/flow.rkt:528:5
actual:     "ba"
expected:   #f
--------------------

```