### PR TITLE
location: adjust path for editors

### DIFF
--- a/rackunit-doc/rackunit/scribblings/utils.scrbl
+++ b/rackunit-doc/rackunit/scribblings/utils.scrbl
@@ -54,3 +54,8 @@ as a predicate and passed each export of the module. If @racket[skip] is
  Re-exports @raco-testing[test-log-enabled?] from @racketmodname[raco/testing].
  @history[#:added "1.1"
           #:changed "1.11" @elem{Allow any value for the parameter and coerce it to a boolean.}]}
+
+@defparam[current-test-invocation-directory test-invocation-directory (or/c #f path-string?) #:value #f]{
+Re-exports @raco-testing[current-test-invocation-directory] from @racketmodname[raco/testing].
+@history[#:added "1.2"]
+}

--- a/rackunit-lib/rackunit/private/check-info.rkt
+++ b/rackunit-lib/rackunit/private/check-info.rkt
@@ -1,10 +1,10 @@
 #lang racket/base
 
 (require racket/contract/base
-         racket/format
          racket/list
          racket/port
          racket/pretty
+         rackunit/log
          "location.rkt"
          (for-syntax racket/base
                      racket/syntax))
@@ -66,7 +66,8 @@
      (write info-value)]))
 
 (define (trim-current-directory path)
-  (define cd (path->string (current-directory)))
+  (define cd (path->string (or (current-test-invocation-directory)
+                               (current-directory))))
   (regexp-replace (regexp-quote cd) path ""))
 
 ;; Infrastructure ----------------------------------------------

--- a/testing-util-lib/info.rkt
+++ b/testing-util-lib/info.rkt
@@ -2,11 +2,11 @@
 (define collection 'multi)
 
 (define deps '("base"
-               ["compiler-lib" #:version "1.13"]))
+               ["compiler-lib" #:version "1.14"]))
 
 (define pkg-desc "Utilities for interoperating between testing frameworks")
 
-(define version "1.1")
+(define version "1.2")
 
 (define pkg-authors '(florence))
 

--- a/testing-util-lib/rackunit/log.rkt
+++ b/testing-util-lib/rackunit/log.rkt
@@ -9,3 +9,4 @@
 (define test-log-enabled? rt:test-log-enabled?)
 (define test-log! rt:test-log!)
 (define test-log rt:test-report)
+(define current-test-invocation-directory rt:current-test-invocation-directory)


### PR DESCRIPTION
Running "raco test foo/bar/test.rkt" will cause Racket to change directory to "foo/bar" before invoking "test.rkt", and error messages are printed relative to (current-directory) like

    raco test: "foo/bar/test.rkt"
    --------------------
    fail
    FAILURE
    name:       check-equal?
    location:   test.rkt:5:0
    actual:     1
    expected:   2
    --------------------
    1/1 test failures

For an editor to consume this, it has to post-process the output to correlate "raco test: path" with "location: partial path" (which is difficult when running tests in parallel). This is not ideal; output with

    location:   foo/bar/test.rkt:5:0

is immediately useable by editors for jumping to the error.

Use the new current-test-invocation-directory to adjust the path better for editors, depending on compiler-lib 1.14. The output now looks like

    raco test: "foo/bar/test.rkt"
    --------------------
    fail
    FAILURE
    name:       check-equal?
    location:   foo/bar/test.rkt:5:0
    actual:     1
    expected:   2
    --------------------
    1/1 test failures

---

Depends on https://github.com/racket/racket/pull/4988.