### PR TITLE
tests: correctly test trim-current-directory

### DIFF
--- a/rackunit-test/tests/rackunit/check-info-test.rkt
+++ b/rackunit-test/tests/rackunit/check-info-test.rkt
@@ -32,6 +32,7 @@
          rackunit
          rackunit/private/check-info
          syntax/srcloc
+         raco/testing
          (submod rackunit/private/check-info for-test))
 
 (module+ test
@@ -141,19 +142,20 @@
       (check-true (check-info-contains-key? info1 'message))
       (check-false (check-info-contains-key? info1 'name))))
 
-  (test-case "All tests for trim-current-directory"
-    (test-case "trim-current-directory leaves directories outside the current directory alone"
-      (check-equal? (trim-current-directory "/foo/bar/") "/foo/bar/"))
-    (test-equal?
-     "trim-current-directory strips directory from files in current directory"
-     (trim-current-directory
-      (path->string (build-path (current-directory) "foo.rkt")))
-     "foo.rkt")
-    (test-equal?
-     "trim-current-directory leaves subdirectories alone"
-     (trim-current-directory
-      (path->string (build-path (current-directory) "foo" "bar.rkt")))
-     "foo/bar.rkt"))
+  (parameterize ([current-test-invocation-directory (current-directory)])
+    (test-case "All tests for trim-current-directory"
+      (test-case "trim-current-directory leaves directories outside the current directory alone"
+        (check-equal? (trim-current-directory "/foo/bar/") "/foo/bar/"))
+      (test-equal?
+       "trim-current-directory strips directory from files in current directory"
+       (trim-current-directory
+        (path->string (build-path (current-directory) "foo.rkt")))
+       "foo.rkt")
+      (test-equal?
+       "trim-current-directory leaves subdirectories alone"
+       (trim-current-directory
+        (path->string (build-path (current-directory) "foo" "bar.rkt")))
+       "foo/bar.rkt")))
 
   (test-case "Do not trample check-info location"
     (let ([srcloc #f] [LINE 1][COL 2][POS 3][SPAN 4])


### PR DESCRIPTION
Now that current-test-invocation-directory is set in parallel mode, this test case fails in DrDr environments with something like

```
--------------------
trim-current-directory strips directory from files in current directory
FAILURE
name:       check-equal?
location: /opt/plt/builds/<current-rev>/trunk/racket/share/pkgs/rackunit-test/tests/rackunit/check-info-test.rkt:147:4
actual: "/opt/plt/builds/<current-rev>/trunk/racket/share/pkgs/rackunit-test/tests/rackunit/foo.rkt"
expected:   "foo.rkt"
--------------------
--------------------
trim-current-directory leaves subdirectories alone
FAILURE
name:       check-equal?
location: /opt/plt/builds/<current-rev>/trunk/racket/share/pkgs/rackunit-test/tests/rackunit/check-info-test.rkt:152:4
actual: "/opt/plt/builds/<current-rev>/trunk/racket/share/pkgs/rackunit-test/tests/rackunit/foo/bar.rkt"
expected:   "foo/bar.rkt"
--------------------
```

Instead of trying to make the tests deal with DrDr's environment, set the current-test-invocation-directory for these tests to the current-directory. In other words: when testing the tester, work around the (meta?) tester to be properly agnostic.

Best viewed with: --ignore--all-space

This should fixup comments on https://github.com/racket/rackunit/pull/175#issuecomment-2122874170.