### PR TITLE
stop catching exn:break exceptions

### DIFF
--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -22,6 +22,10 @@ This means, for instance, checks always evaluate
 their arguments.  You can use a check as a first class
 function, though this will affect the source location that the check grabs.
 
+Also, if the evaluation of the arguments to one of the
+checks raises an exception (except @racket[exn:break?]) the
+exception is caught and the test case is considered to have
+failed.
 
 @section[#:tag "rackunit:basic-checks"]{Basic Checks}
 
@@ -49,6 +53,7 @@ For example, the following checks all fail:
   (check-not-eqv? 1 1 "integers are eqv?")
   (check-equal? 1 1.0 "not equal?")
   (check-not-equal? (list 1) (list 1) "equal?")
+  (check-equal? (car #f) (car #f))
 ]
 }
 
@@ -171,14 +176,18 @@ For example, the following checks succeed:
    exn:fail?
    (lambda ()
      (error 'hi "there")))
+
+  (check-exn exn:fail:contract:divide-by-zero?
+             (lambda ()
+               (/ 1 0)))
 ]
 
 The following check fails:
 
 @interaction[#:eval rackunit-eval
-  (check-exn exn:fail?
+  (check-exn exn:fail:contract:divide-by-zero?
              (lambda ()
-               (break-thread (current-thread))))
+               (car #f)))
   (check-exn
    #rx"Hello there"
    (lambda ()

--- a/rackunit-lib/rackunit/private/result.rkt
+++ b/rackunit-lib/rackunit/private/result.rkt
@@ -115,11 +115,12 @@
       ([exn:test:check?
         (lambda (exn)
           (make-test-failure name exn))]
-       [(lambda _ #t)
+       [not-break-exn?
         (lambda (exn)
           (make-test-error name exn))])
     (let ((value (action)))
       (make-test-success name value))))
+(define (not-break-exn? x) (not (exn:break? x)))
 
 ;; run-test : test -> (list-of test-result)
 ;;

--- a/rackunit-lib/rackunit/private/test-case.rkt
+++ b/rackunit-lib/rackunit/private/test-case.rkt
@@ -24,7 +24,8 @@
 ;;
 ;; Run a test-case immediately, printing information on failure
 (define (default-test-case-around thunk)
-  (with-handlers ([(λ (_) #t) log-and-handle!])
+  (define (not-break-exn? x) (not (exn:break? x)))
+  (with-handlers ([not-break-exn? log-and-handle!])
     (begin0
       (parameterize ((current-custodian (make-custodian)))
         (thunk))

--- a/rackunit-test/tests/rackunit/pr/121.rkt
+++ b/rackunit-test/tests/rackunit/pr/121.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+(require rackunit racket/port)
+(module+ test
+  (define s (make-semaphore))
+  (define op (current-output-port) #;(open-output-nowhere))
+  (define answer (make-channel))
+  (define t
+    (thread
+     (λ ()
+       (parameterize ([current-error-port op]
+                      [current-output-port op])
+         (with-handlers ([exn:break? (λ (x) (channel-put answer 'passed))])
+           (check-equal? (let ()
+                           (semaphore-post s)
+                           (semaphore-wait (make-semaphore 0)))
+                         5)
+           (channel-put answer 'failed))))))
+  (semaphore-wait s)
+  (break-thread t)
+  (unless (equal? (channel-get answer) 'passed)
+    (error "test for pr 121 failed")))


### PR DESCRIPTION
closes #121

If this looks good to people, then let's hold off on this until after the release branches are created, just in case we find something during the next release cycle.