### PR TITLE
fix typing of check-regexp-match, make check return types Void

### DIFF
--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -219,8 +219,8 @@ the check fails.
 
 }
 
-@defproc[(check-regexp-match (regexp (or/c regexp? string?))
-                             (string string?))
+@defproc[(check-regexp-match (regexp (or/c regexp? byte-regexp? string? bytes?))
+                             (string (or/c string? bytes? path? input-port?)))
          void?]{
 
 Checks that @racket[regexp] matches the @racket[string].

--- a/rackunit-doc/rackunit/scribblings/check.scrbl
+++ b/rackunit-doc/rackunit/scribblings/check.scrbl
@@ -219,7 +219,7 @@ the check fails.
 
 }
 
-@defproc[(check-regexp-match (regexp regexp?)
+@defproc[(check-regexp-match (regexp (or/c regexp? string?))
                              (string string?))
          void?]{
 

--- a/rackunit-lib/rackunit/private/util.rkt
+++ b/rackunit-lib/rackunit/private/util.rkt
@@ -84,5 +84,8 @@
       (test-case case-name case-body ...) ...))))
 
 (define-simple-check (check-regexp-match regex string)
-  (and (string? string) 
+  (and (or (string? string)
+           (bytes? string)
+           (path? string)
+           (input-port? string))
        (regexp-match regex string)))

--- a/rackunit-test/tests/rackunit/typed-test.rkt
+++ b/rackunit-test/tests/rackunit/typed-test.rkt
@@ -44,7 +44,7 @@
   (check-regexp-match "a+bba" #"aaaaaabba")
   (check-regexp-match "a+bba" (string->path "aaaaaabba"))
   (call-with-input-string "aaaaaabba"
-    (lambda (in)
+    (lambda ([in : Input-Port])
       (check-regexp-match "a+bba" in))))
 
 

--- a/rackunit-test/tests/rackunit/typed-test.rkt
+++ b/rackunit-test/tests/rackunit/typed-test.rkt
@@ -34,6 +34,10 @@
     test1-report-loc
     (check-eq? 10 20)))
 
+(module typed-check-regexp-match typed/racket/base
+  (require typed/rackunit)
+  (check-regexp-match "a+bba" "aaaaaabba"))
+
 
 (require rackunit racket/port rackunit/text-ui)
 (require 'typed-fail1)
@@ -48,5 +52,6 @@
 (module+ test
   (require (submod ".." typed-success1))
   (require (submod ".." typed-success2))
+  (require (submod ".." typed-check-regexp-match))
   (check-regexp-match (regexp-quote test1-report-loc)
                       report))

--- a/rackunit-test/tests/rackunit/typed-test.rkt
+++ b/rackunit-test/tests/rackunit/typed-test.rkt
@@ -35,8 +35,18 @@
     (check-eq? 10 20)))
 
 (module typed-check-regexp-match typed/racket/base
-  (require typed/rackunit)
-  (check-regexp-match "a+bba" "aaaaaabba"))
+  (require typed/rackunit
+           racket/port)
+  (check-regexp-match #rx"a+bba" "aaaaaabba")
+  (check-regexp-match #rx#"a+bba" "aaaaaabba")
+  (check-regexp-match "a+bba" "aaaaaabba")
+  (check-regexp-match #"a+bba" "aaaaaabba")
+  (check-regexp-match "a+bba" #"aaaaaabba")
+  (check-regexp-match "a+bba" (string->path "aaaaaabba"))
+  (call-with-input-string "aaaaaabba"
+    (lambda (in)
+      (check-regexp-match "a+bba" in))))
+
 
 
 (require rackunit racket/port rackunit/text-ui)

--- a/rackunit-typed/rackunit/main.rkt
+++ b/rackunit-typed/rackunit/main.rkt
@@ -128,7 +128,9 @@
                      (->* () (String) Void))]
                 [(check-regexp-match)
                  (-> #:location Any #:expression Any
-                     (-> (U Regexp String) String Void))])
+                     (-> (U Regexp Byte-Regexp String Bytes)
+                         (U String Bytes Path Input-Port)
+                         Void))])
 
 (define-type (Predicate A) (A -> Boolean))
 (define-type (Thunk A) (-> A))

--- a/rackunit-typed/rackunit/main.rkt
+++ b/rackunit-typed/rackunit/main.rkt
@@ -80,15 +80,15 @@
 (define-type check-impl-ish-ty
   (-> #:location Any #:expression Any
       (case->
-       (-> Any Any Any)
-       (-> Any Any String Any))))
+       (-> Any Any Void)
+       (-> Any Any String Void))))
 
 ;; type for things like `check-true`
 (define-type unary-check-impl-ish-ty
   (-> #:location Any #:expression Any
       (case->
-       (-> Any Any)
-       (-> Any String Any))))
+       (-> Any Void)
+       (-> Any String Void))))
 
 ;; all the actual specifications
 (require-checks [(check-equal? check-eq? check-eqv?
@@ -100,35 +100,35 @@
                  (-> #:location Any #:expression Any
                      (All (A)
                           (case->
-                           ((A -> Any) A -> Any)
-                           ((A -> Any) A String -> Any))))]
+                           ((A -> Any) A -> Void)
+                           ((A -> Any) A String -> Void))))]
                 [(check-=)
                  (-> #:location Any #:expression Any
                      (case->
-                      (Real Real Real -> Any)
-                      (Real Real Real String -> Any)))]
+                      (Real Real Real -> Void)
+                      (Real Real Real String -> Void)))]
                 [(check-exn)
                  (-> #:location Any #:expression Any
                      (case->
-                      ((U (Predicate Any) Regexp) (Thunk Any) -> Any)
-                      ((U (Predicate Any) Regexp) (Thunk Any) String -> Any)))]
+                      ((U (Predicate Any) Regexp) (Thunk Any) -> Void)
+                      ((U (Predicate Any) Regexp) (Thunk Any) String -> Void)))]
                 [(check-not-exn)
                  (-> #:location Any #:expression Any
                      (case->
-                      ((Thunk Any) -> Any)
-                      ((Thunk Any) String -> Any)))]
+                      ((Thunk Any) -> Void)
+                      ((Thunk Any) String -> Void)))]
                 [(check)
                  (-> #:location Any #:expression Any
                      (All (A B)
                           (case->
-                           ((A B -> Any) A B -> Any)
-                           ((A B -> Any) A B String -> Any))))]
+                           ((A B -> Any) A B -> Void)
+                           ((A B -> Any) A B String -> Void))))]
                 [(fail)
                  (-> #:location Any #:expression Any
                      (->* () (String) Void))]
                 [(check-regexp-match)
                  (-> #:location Any #:expression Any
-                     (-> Regexp String Any Any))])
+                     (-> (U Regexp String) String Void))])
 
 (define-type (Predicate A) (A -> Boolean))
 (define-type (Thunk A) (-> A))


### PR DESCRIPTION
## Checklist

- [x] Bugfix
- [x] Feature
- [x] tests included
- [x] documentation

## Description of change

This pull request fixes several issues with `typed/rackunit`. Most importantly, it fixes the implementation and typing for `check-regexp-match` which is incorrectly typed as consuming three arguments but documented as consuming only two.

### [bug] check-regexp-match raises test failure when input is valid but does not conform string?

#### Observation

Consider the following check that uses an `input` argument adhering to `bytes?`:

    (check-regexp-match #rx"a+bba" #"aaaaaabba")

results in:

    --------------------
    FAILURE
     /home/jorgen/test.rkt:10:0
    name:       check-regexp-match
    location:   test.rkt:10:0
    params:     '(#rx"a+bba" #"aaaaaabba")
    --------------------

#### Expectation

Since `regexp-match` matches `check-regexp-match` should pass.

#### Execution

The implementation of `check-regexp-match` has been extended to not fail when valid input values other than `string?` are presented, these could now be `string?`, `bytes?`, `path?`, or `input-port?`.

### [bug] Fix number of arguments for typed check-regexp-match

#### Observation

Consider the following unit test in Typed Racket:

    (check-regexp-match #rx"a+bba" "aaaaaabba")

    Type Checker: could not apply function;
     wrong number of arguments provided
      expected: 3
      given: 2
      in: #%module-begin

does not type. Adding a bogus argument makes the check pass:

    (check-regexp-match #rx"a+bba" "aaaaaabba" #f)

Similarly, we can produce a failing test with a bogus argument:

    (check-regexp-match #rx"a+bba" "aaaaaabb" #f)

#### Expectation

Calling `check-regexp-match` should produce a passing test if only two arguments are provided.

#### Execution

This pull request removes the extra argument from the type specification of `check-regexp-match`.

### [feature] Extend check-regexp-match to support the range of input arguments supported by regexp-match

#### Observation

The documentation of `check-regexp-match` provides the following example:

    (check-regexp-match "a+bba" "aaaaaabba")

In Typed Racket, however, this example fails not just because the type spec declares an extra argument (see above) but also because the first argument is restricted to be of type `Regexp` and here we provide a `String`.

#### Expectation

Since `check-regexp-match` uses `regexp-match` to create a unit test I would expect all arguments that can be passed to `regexp-match` to be valid also for `check-regexp-match`. Especially the above example from the documentation should type and pass.

#### Execution

This pull request extends the type spec for `check-regexp-match` to include `Regexp`, `Byte-Regexp`, `String`, and `Bytes` as valid regexp patterns. Also, it allows the input to be a `String`, `Bytes`, `Path`, or `Input-Port`.

### [bug] Correct check function return value types from Any to Void

#### Observation

Consider the following procedure:

    (: proc (-> Natural Void))
    (define (proc x)
      (check-eq? x 5))

This function fails to type raising:

    Type Checker: type mismatch
      expected: Void
      given: Any
      in: (define (proc x) (check-eq? x 5))


#### Expectation

The above function should type because `check-eq?`'s first argument is `Any` and `Natural` is a subtype of `Any`. The documenation says that `check-eq?` returns `void?`, so I expected the corresponding type to be `Void`. Setting the return type to `Any` works but is inadequate because the documentation says, it returns `void?`, not `any/c`.

#### Execution

All check's type specs have been updated to return `Void`.

### [doc] Update documentation

The documentation has been extended to account for the extended contract for `check-regexp-match`.






