### PR TITLE
typed/private/utils and typed/private/rewriter are not used

### DIFF
--- a/rackunit-typed/rackunit/gui.rkt
+++ b/rackunit-typed/rackunit/gui.rkt
@@ -1,6 +1,5 @@
 #lang typed/racket
-(require typed/rackunit
-         typed/private/utils)
+(require typed/rackunit)
 
 (require/typed/provide
  rackunit/gui

--- a/rackunit-typed/rackunit/main.rkt
+++ b/rackunit-typed/rackunit/main.rkt
@@ -1,8 +1,6 @@
 #lang typed/racket
 #:no-optimize ;; precaution, because of unsafe-provide
 (require typed/racket/class
-         typed/private/utils
-         typed/private/rewriter
          "type-env-ext.rkt"
          (for-syntax syntax/parse syntax/srcloc racket/syntax)
          (for-syntax syntax/parse)

--- a/rackunit-typed/rackunit/text-ui.rkt
+++ b/rackunit-typed/rackunit/text-ui.rkt
@@ -1,6 +1,5 @@
 #lang typed/racket
-(require typed/rackunit
-         typed/private/utils)
+(require typed/rackunit)
 
 (define-type Verbosity
   (U 'quiet 'normal 'verbose))


### PR DESCRIPTION
There imports are not used and can be safely removed.